### PR TITLE
구매 관련 엔티티(CartItem, Payment, Cart)의 'memberId' 도메인을 외래키로 설정함

### DIFF
--- a/AutumnShop/src/main/java/com/example/AutumnMall/domain/Cart.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/domain/Cart.java
@@ -19,8 +19,9 @@ public class Cart {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne
     @JoinColumn(name = "member_id")
-    private Long memberId;
+    private Member member;
 
     private String date; // yyyymmdd
 

--- a/AutumnShop/src/main/java/com/example/AutumnMall/domain/Payment.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/domain/Payment.java
@@ -23,7 +23,10 @@ public class Payment {
     private Double productRate;
     private int quantity;
 
-    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     private LocalDate date;
 
     @ManyToOne

--- a/AutumnShop/src/main/java/com/example/AutumnMall/repository/CartItemRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/repository/CartItemRepository.java
@@ -1,6 +1,7 @@
 package com.example.AutumnMall.repository;
 
 import com.example.AutumnMall.domain.CartItem;
+import com.example.AutumnMall.domain.Member;
 import com.example.AutumnMall.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,18 +9,18 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
-    boolean existsByCart_memberIdAndCart_idAndProductId(Long memberId, Long cartId, Long productId);
-    Optional<CartItem> findByCart_memberIdAndCart_idAndProductId(Long memberId, Long cartId, Long productId);
+    boolean existsByCart_memberAndCart_idAndProductId(Member memberId, Long cartId, Long productId);
+    Optional<CartItem> findByCart_memberAndCart_idAndProductId(Member memberId, Long cartId, Long productId);
 
-    boolean existsByCart_memberIdAndCartId(Long memberId, Long cartItemId);
-    Integer deleteByCart_memberId(Long memberId);
+    boolean existsByCart_memberAndCartId(Member memberId, Long cartItemId);
+    Integer deleteByCart_member(Member memberId);
 
 
-    List<CartItem> findByCart_memberIdAndCart_id(Long memberId, Long cartId);
+    List<CartItem> findByCart_memberAndCart_id(Member memberId, Long cartId);
 
-    List<CartItem> findByCart_memberId(Long memberId);
+    List<CartItem> findByCart_Member(Member memberId);
 
-    List<CartItem> findByCart_IdAndCart_MemberId(Long cartId, Long memberId);
+    List<CartItem> findByCart_IdAndCart_Member(Long cartId, Member memberId);
 
     List<CartItem> deleteByCartId(Long cartItemId);
 

--- a/AutumnShop/src/main/java/com/example/AutumnMall/repository/CartRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/repository/CartRepository.java
@@ -1,12 +1,13 @@
 package com.example.AutumnMall.repository;
 
 import com.example.AutumnMall.domain.Cart;
+import com.example.AutumnMall.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CartRepository  extends JpaRepository<Cart, Long> {
-    Optional<Cart> findByMemberIdAndDate(Long memberId, String date);
+    Optional<Cart> findByMemberAndDate(Member member, String date);
 
-    Optional<Cart> findByMemberId(Long memberId);
+    Optional<Cart> findByMember(Member member);
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/repository/PaymentRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/repository/PaymentRepository.java
@@ -1,5 +1,6 @@
 package com.example.AutumnMall.repository;
 
+import com.example.AutumnMall.domain.Member;
 import com.example.AutumnMall.domain.Payment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,11 +10,12 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
-    List<Payment> findByMemberId(Long memberId);
+    List<Payment> findByMember(Member member);
 
-    Page<Payment> findByMemberIdAndDateBetween(Long memberId, LocalDate startDate, LocalDate endDate, Pageable pageable);
+    Page<Payment> findByMemberAndDateBetween(Member member, LocalDate startDate, LocalDate endDate, Pageable pageable);
 
-    Page<Payment> findAllByMemberId(Long memberId, Pageable pageable);
+    Page<Payment> findAllByMember(Member member, Pageable pageable);
 
     List<Payment> findByOrderId(Long orderId);
+
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/service/CartItemService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/service/CartItemService.java
@@ -1,5 +1,6 @@
 package com.example.AutumnMall.service;
 
+import com.example.AutumnMall.domain.Member;
 import com.example.AutumnMall.domain.Product;
 import com.example.AutumnMall.dto.ResponseGetCartItemDto;
 import com.example.AutumnMall.repository.CartItemRepository;
@@ -7,6 +8,7 @@ import com.example.AutumnMall.repository.CartRepository;
 import com.example.AutumnMall.domain.Cart;
 import com.example.AutumnMall.domain.CartItem;
 import com.example.AutumnMall.dto.AddCartItemDto;
+import com.example.AutumnMall.repository.MemberRepository;
 import com.example.AutumnMall.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +23,8 @@ public class CartItemService {
     private final CartItemRepository cartItemRepository;
     private final CartRepository cartRepository;
     private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+
 
     @Transactional
     public CartItem addCartItem(AddCartItemDto addCartItemDto) {
@@ -37,13 +41,17 @@ public class CartItemService {
 
     @Transactional(readOnly = true)
     public boolean isCartItemExist(Long memberId, Long cartId, Long productId) {
-        boolean check = cartItemRepository.existsByCart_memberIdAndCart_idAndProductId(memberId, cartId, productId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+        boolean check = cartItemRepository.existsByCart_memberAndCart_idAndProductId(member, cartId, productId);
         return check;
     }
 
     @Transactional(readOnly = true)
     public CartItem getCartItem(Long memberId, Long cartId, Long productId) {
-        return cartItemRepository.findByCart_memberIdAndCart_idAndProductId(memberId, cartId, productId).orElseThrow();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+        return cartItemRepository.findByCart_memberAndCart_idAndProductId(member, cartId, productId).orElseThrow();
     }
 
     @Transactional
@@ -55,12 +63,16 @@ public class CartItemService {
 
     @Transactional(readOnly = true)
     public boolean isCartItemExist(Long memberId, Long cartItemId) {
-        return cartItemRepository.existsByCart_memberIdAndCartId(memberId, cartItemId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+        return cartItemRepository.existsByCart_memberAndCartId(member, cartItemId);
     }
 
     @Transactional(readOnly = true)
     public List<ResponseGetCartItemDto> getCartItems(Long memberId, Long cartId) {
-        List<CartItem> cartItems = cartItemRepository.findByCart_IdAndCart_MemberId(cartId, memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+        List<CartItem> cartItems = cartItemRepository.findByCart_IdAndCart_Member(cartId, member);
 
         return cartItems.stream()
                 .map(cartItem -> {
@@ -80,7 +92,9 @@ public class CartItemService {
 
     @Transactional(readOnly = true)
     public List<ResponseGetCartItemDto> getCartItems(Long memberId) {
-        List<CartItem> cartItems = cartItemRepository.findByCart_memberId(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+        List<CartItem> cartItems = cartItemRepository.findByCart_Member(member);
 
         return cartItems.stream().map(cartItem -> new ResponseGetCartItemDto(
                 cartItem.getId(),

--- a/AutumnShop/src/main/java/com/example/AutumnMall/service/CartService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/service/CartService.java
@@ -1,7 +1,9 @@
 package com.example.AutumnMall.service;
 
+import com.example.AutumnMall.domain.Member;
 import com.example.AutumnMall.repository.CartRepository;
 import com.example.AutumnMall.domain.Cart;
+import com.example.AutumnMall.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,11 +13,15 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class CartService {
     private final CartRepository cartRepository;
+    private final MemberRepository memberRepository;
+
     public Cart addCart(Long memberId, String date) {
-        Optional<Cart> cart = cartRepository.findByMemberId(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+        Optional<Cart> cart = cartRepository.findByMember(member);
         if(cart.isEmpty()) {
             Cart newCart = new Cart();
-            newCart.setMemberId(memberId);
+            newCart.setMember(member);
             newCart.setDate(date);
             Cart saveCart = cartRepository.save(newCart);
             return saveCart;
@@ -24,6 +30,9 @@ public class CartService {
         }
     }
     public Optional<Cart> findByMemberId(Long memberId) {
-        return cartRepository.findByMemberId(memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+        return cartRepository.findByMember(member);
     }
 }


### PR DESCRIPTION
1. memberId에 해당하는 JPA들을 외래키 규정에 맞게 member로 전부 수정

close #6 