### PR TITLE
비밀번호 변경 기능 추가

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/mypage/index.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/index.js
@@ -35,6 +35,10 @@ const MyPage = () => {
     window.location.href = "http://localhost:3000/mypage/myWrite";
   };
 
+  const passwordClick = () => {
+    window.location.href= "http://localhost:3000/mypage/passwordEdit";
+  }
+
   if (!userInfo) {
     return <div>Loading...</div>;
   }
@@ -61,6 +65,16 @@ const MyPage = () => {
         <Typography variant="h5">
           성별: {userInfo.gender === "M" ? "남자" : "여자"}
         </Typography>
+        <div>
+        <Button
+        variant="contained"
+        color="primary"
+        sx={{ marginTop: 2}}
+        onClick={passwordClick}
+        >
+          비밀번호 변경
+          </Button>
+          </div>
         <Button 
           variant="contained" 
           color="primary" 

--- a/AutumnShop/front/Autumnshop/pages/mypage/myWrite.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/myWrite.js
@@ -64,7 +64,6 @@ const myWriteForm = () => {
 
   // 상태 설정 추가
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [name, setName] = useState("");
   const [gender, setGender] = useState("");
   const [phone, setPhone] = useState("");
@@ -97,8 +96,8 @@ const myWriteForm = () => {
 
     const memberSignupDto = {
       email,
-      password,
       name,
+      password: "",
       birthYear,
       birthMonth,
       birthDay,
@@ -149,16 +148,6 @@ const myWriteForm = () => {
           required
           value={email}
           InputProps={{ readOnly: true }}
-        />
-        <TextField
-          label="암호"  
-          type="password"
-          variant="outlined"
-          margin="normal"
-          fullWidth
-          required
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
         />
         <TextField
           label="생년월일"

--- a/AutumnShop/front/Autumnshop/pages/mypage/passwordEdit.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/passwordEdit.js
@@ -1,0 +1,122 @@
+import React, { useState } from "react";
+import { TextField, Button, Container, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import axios from "axios";
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    maxWidth: "500px",
+    height: "100%",
+    margin: "0 auto",
+  },
+  form: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+  },
+  button: {
+    marginTop: theme.spacing(2),
+  },
+}));
+
+const PasswordChange = () => {
+  const classes = useStyles();
+  const [oldPassword, setOldPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  // 비밀번호 변경 처리 함수
+  const handlePasswordChange = async () => {
+    if (newPassword !== confirmPassword) {
+      setErrorMessage("새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.");
+      return;
+    }
+
+    try {
+      const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+      const response = await axios.patch(
+        "http://localhost:8080/members/changePassword",
+        {
+          oldPassword,
+          newPassword,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${loginInfo.accessToken}`,
+          },
+        }
+      );
+
+      if (response.status === 200) {
+        alert("비밀번호가 성공적으로 변경되었습니다.");
+        setOldPassword("");
+        setNewPassword("");
+        setConfirmPassword("");
+        setErrorMessage("");
+        window.location.href = "http://localhost:3000/mypage";
+
+      }
+    } catch (error) {
+      setErrorMessage("비밀번호 변경에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  return (
+    <Container className={classes.container}>
+      <Typography variant="h6">비밀번호 변경</Typography>
+      <form className={classes.form} noValidate autoComplete="off">
+        <TextField
+          label="현재 비밀번호"
+          variant="outlined"
+          type="password"
+          value={oldPassword}
+          onChange={(e) => setOldPassword(e.target.value)}
+          fullWidth
+          required
+          margin="normal"
+        />
+        <TextField
+          label="새 비밀번호"
+          variant="outlined"
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          fullWidth
+          required
+          margin="normal"
+        />
+        <TextField
+          label="새 비밀번호 확인"
+          variant="outlined"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          fullWidth
+          required
+          margin="normal"
+        />
+        {errorMessage && (
+          <Typography color="error" variant="body2" style={{ marginTop: "10px" }}>
+            {errorMessage}
+          </Typography>
+        )}
+        <Button
+          variant="contained"
+          color="primary"
+          className={classes.button}
+          onClick={handlePasswordChange}
+        >
+          비밀번호 변경
+        </Button>
+      </form>
+    </Container>
+  );
+};
+
+export default PasswordChange;

--- a/AutumnShop/src/main/java/com/example/AutumnMall/dto/MemberUpdateDto.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/dto/MemberUpdateDto.java
@@ -1,0 +1,62 @@
+package com.example.AutumnMall.dto;
+
+import javax.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUpdateDto {
+
+    @NotEmpty
+    @Pattern(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+            message = "이메일 형식을 맞춰야합니다")
+    private String email;
+
+    @NotEmpty
+    @Pattern(regexp = "^[a-zA-Z가-힣\\\\s]{2,15}",
+            message = "이름은 영문자, 한글, 공백포함 2글자부터 15글자까지 가능합니다.")
+    private String name;
+
+    @NotNull
+    @Pattern(regexp = "^\\d{4}$", message = "생년은 4자리 숫자로 입력해야 합니다")
+    private String birthYear;
+
+    @NotNull
+    @Pattern(regexp = "^(0?[1-9]|1[012])$", message = "생월은 1부터 12까지의 숫자로 입력해야 합니다")
+    private String birthMonth;
+
+    @NotNull
+    @Pattern(regexp = "^(0?[1-9]|[12][0-9]|3[01])$", message = "생일은 1부터 31까지의 숫자로 입력해야 합니다")
+    private String birthDay;
+
+    @NotEmpty
+    @Pattern(regexp = "^[MF]{1}$", message = "성별은 'M' 또는 'F'로 입력해야 합니다")
+    private String gender;
+
+    @NotNull(message = "전화번호는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^(010|031|032)-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private String phone;
+
+    // 도로명 주소 패턴 검증 (예시: 서울특별시 강남구 삼성로 85)
+    @NotNull(message = "도로명 주소는 필수 입력 사항입니다.")
+    @Length(min = 5, max = 100, message = "도로명 주소는 최소 5자 이상 100자 이하이어야 합니다.")
+    @Pattern(
+            regexp = "^[가-힣A-Za-z·\\d~\\-\\.\\s]+(로|길)\\s\\d+(-\\d+)*\\s?\\d*$",
+            message = "도로명 주소 형식이 올바르지 않습니다."
+    )
+    private String roadAddress;
+
+    @NotNull(message = "우편번호는 필수 입력 사항입니다.")
+    @Pattern(regexp = "^\\d{5}$", message = "우편번호 형식이 올바르지 않습니다. 형식: 12345")
+    private String zipCode;
+
+    @NotNull(message = "상세주소를 입력해주세요.")
+    private String detailAddress;
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/dto/PasswordChangeDto.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/dto/PasswordChangeDto.java
@@ -1,0 +1,16 @@
+package com.example.AutumnMall.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+public class PasswordChangeDto {
+    @NotBlank(message = " 기존 비밀번호를 입력하세요.")
+    private String oldPassword;
+
+    @NotBlank(message = " 새 비밀번호를 입력하세요.")
+    private String newPassword;
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/service/MemberService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.AutumnMall.service;
 import com.example.AutumnMall.domain.Member;
 import com.example.AutumnMall.domain.Role;
 import com.example.AutumnMall.dto.MemberSignupDto;
+import com.example.AutumnMall.dto.MemberUpdateDto;
 import com.example.AutumnMall.repository.MemberRepository;
 import com.example.AutumnMall.repository.RoleRepository;
 import lombok.RequiredArgsConstructor;
@@ -56,49 +57,56 @@ public class MemberService {
     }
 
     @Transactional
-    public Member updateMember(MemberSignupDto memberSignupDto){
+    public Member updateMember(MemberUpdateDto memberUpdateDto){
         // 업데이트할 멤버 검색
-        Optional<Member> existingMember = memberRepository.findByEmail(memberSignupDto.getEmail());
+        Optional<Member> existingMember = memberRepository.findByEmail(memberUpdateDto.getEmail());
         Member member = existingMember.get();
 
         // 수정할 정보만 업데이트
-        updateMemberWrite(member, memberSignupDto);
+        updateMemberWrite(member, memberUpdateDto);
         return memberRepository.save(member);
     }
 
-    private void updateMemberWrite(Member member, MemberSignupDto memberSignupDto) {
-        if (memberSignupDto.getName() != null) {
-            member.setName(memberSignupDto.getName());
+    @Transactional
+    public Member updateMemberPassword(Long memberId, String newPassword){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        member.setPassword(passwordEncoder.encode(newPassword));
+        return memberRepository.save(member);
+    }
+
+    // 멤버의 업데이트할 정보만 갱신
+    private void updateMemberWrite(Member member, MemberUpdateDto memberUpdateDto) {
+        if (memberUpdateDto.getName() != null) {
+            member.setName(memberUpdateDto.getName());
         }
-        if (memberSignupDto.getEmail() != null) {
-            member.setEmail(memberSignupDto.getEmail());
+        if (memberUpdateDto.getEmail() != null) {
+            member.setEmail(memberUpdateDto.getEmail());
         }
-        if (memberSignupDto.getPassword() != null) {
-            member.setPassword(passwordEncoder.encode(memberSignupDto.getPassword()));
+
+        if (memberUpdateDto.getBirthYear() != null) {
+            member.setBirthYear(Integer.parseInt(memberUpdateDto.getBirthYear()));
         }
-        if (memberSignupDto.getBirthYear() != null) {
-            member.setBirthYear(Integer.parseInt(memberSignupDto.getBirthYear()));
+        if (memberUpdateDto.getBirthMonth() != null) {
+            member.setBirthMonth(Integer.parseInt(memberUpdateDto.getBirthMonth()));
         }
-        if (memberSignupDto.getBirthMonth() != null) {
-            member.setBirthMonth(Integer.parseInt(memberSignupDto.getBirthMonth()));
+        if (memberUpdateDto.getBirthDay() != null) {
+            member.setBirthDay(Integer.parseInt(memberUpdateDto.getBirthDay()));
         }
-        if (memberSignupDto.getBirthDay() != null) {
-            member.setBirthDay(Integer.parseInt(memberSignupDto.getBirthDay()));
+        if (memberUpdateDto.getGender() != null) {
+            member.setGender(memberUpdateDto.getGender());
         }
-        if (memberSignupDto.getGender() != null) {
-            member.setGender(memberSignupDto.getGender());
+        if (memberUpdateDto.getPhone() != null) {
+            member.setPhone(memberUpdateDto.getPhone());
         }
-        if (memberSignupDto.getPhone() != null) {
-            member.setPhone(memberSignupDto.getPhone());
+        if (memberUpdateDto.getRoadAddress() != null) {
+            member.setRoadAddress(memberUpdateDto.getRoadAddress());
         }
-        if (memberSignupDto.getRoadAddress() != null) {
-            member.setRoadAddress(memberSignupDto.getRoadAddress());
+        if (memberUpdateDto.getZipCode() != null) {
+            member.setZipCode(memberUpdateDto.getZipCode());
         }
-        if (memberSignupDto.getZipCode() != null) {
-            member.setZipCode(memberSignupDto.getZipCode());
-        }
-        if (memberSignupDto.getDetailAddress() != null) {
-            member.setDetailAddress(memberSignupDto.getDetailAddress());
+        if (memberUpdateDto.getDetailAddress() != null) {
+            member.setDetailAddress(memberUpdateDto.getDetailAddress());
         }
     }
 }


### PR DESCRIPTION
close #7 
1. 비밀번호 변경을 할 수 있도록 내 정보 페이지에 추가 
2.1 새 비밀번호와 새 비밀번호 확인과 비교하여 같지 않을 경우 실행하지 않음
2.2 기존 비밀번호와 새 비밀번호가 같을 경우에만 실행
(회원가입과 같은 Dto를 써서 문제가 생겨 새로 'PasswordChangeDto' 생성) 
2.3 비밀번호 기능 완성 후, 멤버 정보 업데이트 페이지에서 '비밀번호' 공간을 삭제하였음. 
2.4 기존의 MemberService의 UpdateMember에서 패스워드에서 한번 더 encode해서 패스워드가 변경된 점을 수정함