### PR TITLE
마일리지 소멸 기능 완성

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/mypage/mileageHistory.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/mileageHistory.js
@@ -133,6 +133,7 @@ const mileageHistory = () => {
                 <thead>
                     <tr className={classes.tableHeader}>
                         <th className={classes.tableCell}>날짜</th>
+                        <th className={classes.tableCell}>유형</th>
                         <th className={classes.tableCell}>상세내역</th>
                         <th className={classes.tableCell}>마일리지</th>
                     </tr>
@@ -143,7 +144,11 @@ const mileageHistory = () => {
                             <tr key={mileage.id} className={classes.tableRow}>
                                 <td className={classes.tableCell}>{mileage.date}</td>
                                 <td className={classes.tableCell}>
-                                    {mileage.type === "ADD" ? "마일리지 적립" : "마일리지 소모"}
+                                    {mileage.type === "ADD" && "적립"}
+                                    {mileage.type === "MINUS" && "사용"}
+                                    {mileage.type === "EXPIRATION" && "소멸"}
+                                </td>
+                                <td className={classes.tableCell}>{mileage.description}
                                 </td>
                                 <td className={classes.tableCell}>
                                     {mileage.amount.toLocaleString()}원
@@ -152,7 +157,7 @@ const mileageHistory = () => {
                         ))
                     ) : (
                         <tr>
-                            <td colSpan={3} className={classes.tableCell}>
+                            <td colSpan={4} className={classes.tableCell}>
                                 마일리지 내역이 없습니다.
                             </td>
                         </tr>
@@ -193,7 +198,7 @@ const mileageHistory = () => {
                 <button
                     className={classes.paginationButton}
                     onClick={() => PageChange(totalPages - 1)}
-                    // pAGE가 끝 페이지일 경우 작동하지 않음
+                    // Page가 끝 페이지일 경우 작동하지 않음
                     disabled={currentPage === totalPages - 1}
                 >
                     마지막

--- a/AutumnShop/front/Autumnshop/pages/welcome.js
+++ b/AutumnShop/front/Autumnshop/pages/welcome.js
@@ -1,6 +1,30 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+
 
 const WelcomePage = () => {
+  useEffect(() => {
+    const mileageExpire = async () => {
+      try {
+        const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+        const getMileageExpireResponse = await axios.post(
+          "http://localhost:8080/mileage/expire",
+          {},
+          {
+            headers: {
+              Authorization: `Bearer ${loginInfo.accessToken}`,
+            },
+          }
+        );
+    
+      } catch (error) {
+        console.error("멤버 정보를 불러오지 못했습니다.");
+      }
+    };
+
+    mileageExpire();
+  }, []);
+
   return (
     <div>
       <h1>환영합니다.</h1>

--- a/AutumnShop/src/main/java/com/example/AutumnMall/controller/MileageController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/controller/MileageController.java
@@ -34,6 +34,13 @@ public class MileageController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/expire")
+    public ResponseEntity<Void> expireMileage(@IfLogin LoginUserDto loginUserDto){
+        mileageService.expireMileage(loginUserDto.getMemberId());
+        mileageService.updateMileage(loginUserDto.getMemberId());
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/history")
     public ResponseEntity<Page<Mileage>> getMileageHistory(@IfLogin LoginUserDto loginUserDto,
                                                            @RequestParam int page,

--- a/AutumnShop/src/main/java/com/example/AutumnMall/domain/Mileage.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/domain/Mileage.java
@@ -28,14 +28,17 @@ public class Mileage {
     @Column(nullable = false)
     private int amount; // 마일리지 값
 
-    @Column(nullable = false, length = 50)
-    private String type; // 마일리지 타입 ( 적립, 사용, 소멸)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MileageType type; // 마일리지 타입 ( 적립, 사용, 소멸)
 
     @Column(nullable = false, length = 255)
     private String description; // 설명 ( 상품 구매 적립, 사용, 소멸)
 
     @CreationTimestamp
     private LocalDate date;
+
+    private LocalDate expirationDate; // 마일리지 소멸 날짜
 
 
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/domain/MileageType.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/domain/MileageType.java
@@ -1,0 +1,8 @@
+package com.example.AutumnMall.domain;
+
+public enum MileageType {
+    ADD, // 적립
+    MINUS, // 사용
+    EXPIRATION, // 소멸
+
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/repository/MileageRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/repository/MileageRepository.java
@@ -2,10 +2,19 @@ package com.example.AutumnMall.repository;
 
 import com.example.AutumnMall.domain.Member;
 import com.example.AutumnMall.domain.Mileage;
+import com.example.AutumnMall.domain.MileageType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface MileageRepository extends JpaRepository<Mileage, Long> {
     Page<Mileage> findByMember(Member member, Pageable pageable);
+
+    // 소멸 마일리지 조회
+    List<Mileage> findByMemberAndExpirationDateBeforeAndType(Member member, LocalDate expirationDate, MileageType type);
+
+    List<Mileage> findByMemberAndType(Member member, MileageType type);
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/service/MileageService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/service/MileageService.java
@@ -2,13 +2,18 @@ package com.example.AutumnMall.service;
 
 import com.example.AutumnMall.domain.Member;
 import com.example.AutumnMall.domain.Mileage;
+import com.example.AutumnMall.domain.MileageType;
 import com.example.AutumnMall.repository.MemberRepository;
 import com.example.AutumnMall.repository.MileageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 
 @Service
@@ -28,8 +33,9 @@ public class MileageService {
         Mileage mileage = Mileage.builder()
                 .member(member)
                 .amount(amount)
-                .type("ADD")
+                .type(MileageType.ADD)
                 .description("마일리지 적립")
+                .expirationDate(LocalDate.now().plusDays(3))
                 .build();
 
         member.setTotalMileage(member.getTotalMileage() + amount);
@@ -44,14 +50,61 @@ public class MileageService {
         Mileage mileage = Mileage.builder().
                 member(member)
                 .amount(amount)
-                .type("MINUS")
+                .type(MileageType.MINUS)
                 .description("마일리지 소모")
+                .expirationDate(LocalDate.now())
                 .build();
 
         member.setTotalMileage(member.getTotalMileage() - amount);
         mileageRepository.save(mileage);
     }
 
+    @Transactional
+    public void expireMileage(Long memberId) {
+        LocalDate now = LocalDate.now();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        // 만료된 적립 마일리지 목록
+        List<Mileage> expiredMileage = mileageRepository.findByMemberAndExpirationDateBeforeAndType(
+                member, now, MileageType.ADD);
+
+        // 만료된 마일리지 기록 추가 및 기존 마일리지 업데이트
+        for (Mileage mileage : expiredMileage) {
+
+            // 기존 마일리지 소멸 처리
+            mileage.setType(MileageType.EXPIRATION);
+            mileage.setDescription("마일리지 적립 후 소멸");
+
+            mileageRepository.save(mileage);    // 기존 마일리지 업데이트
+        }
+    }
+
+    @Transactional
+    public void updateMileage(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        // `ADD`, `MINUS`, `EXPIRATION` 유형 모두 반영하여 총 마일리지 계산
+        int addMileageTotal = mileageRepository.findByMemberAndType(member, MileageType.ADD).stream()
+                .mapToInt(Mileage::getAmount)
+                .sum();
+
+        int minusMileageTotal = mileageRepository.findByMemberAndType(member, MileageType.MINUS).stream()
+                .mapToInt(Mileage::getAmount)
+                .sum();
+
+        int expirationMileageTotal = mileageRepository.findByMemberAndType(member, MileageType.EXPIRATION).stream()
+                .mapToInt(Mileage::getAmount)
+                .sum();
+
+        // 먼저 만료된 마일리지에서 사용 마일리지를 차감하고, 남은 게 있다면 적립 마일리지에서 차감
+        int expminus = minusMileageTotal - expirationMileageTotal;
+        if(expminus > 0)
+            member.setTotalMileage(addMileageTotal - expminus);
+        else
+            member.setTotalMileage(addMileageTotal);
+    }
 
     public Page<Mileage> getMileageHistory(Long memberId, Pageable pageable){
         Member member = memberRepository.findById(memberId)


### PR DESCRIPTION
1. 로그인하고 들어갔을 때의 홈페이지에서 기능이 작동하도록 함 
(메인페이지가 아닌 /welcome 페이지에서 하도록 함)
2. 마일리지의 타입을 enum으로 선언해서, '적립, 사용, 소멸'의 세가지 타입으로 함
3. 마일리지 적립 날짜에서 **3일**이 지났을 경우, **적립**타입에서 **소멸**타입으로 바꿈
4. 사용자의 현재 마일리지의 계산식을 다음과 같이 하고 적용하도록 함 
(사용 마일리지에서 소멸 마일리지를 뺀 후, 사용 마일리지가 0보다 클 경우 적립 마일리지에서 뺌.)
추가로, 마일리지 내역에서 설명란 추가 