### PR TITLE
#4

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/mypage/index.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/index.js
@@ -93,6 +93,17 @@ const MyPage = () => {
           </Link>
         </div>
         <div>
+          <Link href={`/mypage/recentProducts`} passHref>
+          <Button
+            variant="contained"
+            color="primary"
+            sx={{ marginTop : 2}}
+            >
+              최근 본 상품 보기
+            </Button>
+            </Link>
+        </div>
+        <div>
           <Link href={`/mypage/passCheck`} passHref>
         <Button 
           variant="contained" 

--- a/AutumnShop/front/Autumnshop/pages/mypage/recentProducts.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/recentProducts.js
@@ -1,0 +1,10 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { makeStyles } from "@mui/styles";
+import Link from "next/link";
+
+const RecentProduct = () => {
+
+}
+
+export default RecentProduct;

--- a/AutumnShop/front/Autumnshop/pages/mypage/recentProducts.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/recentProducts.js
@@ -2,9 +2,149 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { makeStyles } from "@mui/styles";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { Button } from "@mui/material";
 
-const RecentProduct = () => {
+const useStyles = makeStyles(() => ({
+  container: {
+    padding: "20px",
+    border: "1px solid #ccc",
+    borderRadius: "8px",
+    backgroundColor: "#f8f8f8",
+    textAlign: "center",
+    maxWidth: "800px",
+    margin: "20px auto",
+  },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+  },
+  tableHeader: {
+    backgroundColor: "#3f51b5",
+    color: "#fff",
+    fontWeight: "bold",
+    textAlign: "center",
+    padding: "12px",
+  },
+  tableCell: {
+    border: "1px solid #ddd",
+    padding: "12px",
+    textAlign: "center",
+  },
+  tableRow: {
+    "&:hover": {
+      backgroundColor: "#f1f1f1",
+    },
+  },
+  button: {
+    padding: "8px 16px",
+    fontSize: "14px",
+    fontWeight: "bold",
+    color: "#fff",
+    backgroundColor: "#007BFF",
+    border: "none",
+    borderRadius: "4px",
+    cursor: "pointer",
+    transition: "background-color 0.3s ease, transform 0.2s ease",
+    "&:hover": {
+      backgroundColor: "#0056b3",
+      transform: "scale(1.05)",
+    },
+    "&:active": {
+      backgroundColor: "#003f7f",
+      transform: "scale(0.95)",
+    },
+  },
+}));
 
+// getRecentProducts 함수 한 번만 불러올 수 있도록 함
+let isRequestingRecentProduct = false;
+
+async function getRecentProducts(setRecentProducts) {
+    if(isRequestingRecentProduct) return;
+    isRequestingRecentProduct = true;
+  try {
+    const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+
+    if (!loginInfo || !loginInfo.accessToken) {
+      alert("로그인을 해주세요");
+      window.location.href = "/login"; // 로그인 페이지로 리다이렉트
+      return;
+    }
+
+    const getRecentProductsResponse = await axios.get("http://localhost:8080/recentProducts", {
+      headers: {
+        Authorization: `Bearer ${loginInfo.accessToken}`,
+      },
+    });
+
+    if(!getRecentProductsResponse.data.length)
+        alert("최근 본 상품이 없습니다!");
+
+    // 최근 본 상품 목록을 최신 순으로 정렬
+    setRecentProducts(getRecentProductsResponse.data.reverse()); // reverse()로 최신 순 정렬
+  } catch (error) {
+    console.error("최근 본 상품을 불러오지 못했습니다.");
+  } finally {
+    isRequestingRecentProduct = false;
+  }
 }
 
-export default RecentProduct;
+const RecentProducts = () => {
+  const classes = useStyles();
+  const [recentProducts, setRecentProducts] = useState([]);
+
+  useEffect(() => {
+    getRecentProducts(setRecentProducts);
+  }, []);
+
+  if (!recentProducts.length) {
+    return (
+      <div className={classes.container}>
+        <h3>최근 본 상품</h3>
+        <p>최근 본 상품이 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes.container}>
+      <h3>최근 본 상품</h3>
+      <table className={classes.table}>
+        <thead>
+          <tr>
+            <th className={classes.tableHeader}>이미지</th>
+            <th className={classes.tableHeader}>제품명</th>
+            <th className={classes.tableHeader}>가격</th>
+            <th className={classes.tableHeader}>상세</th>
+          </tr>
+        </thead>
+        <tbody>
+          {recentProducts.map((product) => (
+            <tr
+              key={product.id}
+              className={classes.tableRow}
+            >
+              <td className={classes.tableCell}>
+                <img
+                  src={product.imageUrl}
+                  alt={product.title}
+                  style={{ width: "100px", height: "100px", objectFit: "cover", borderRadius: "8px" }}
+                />
+              </td>
+              <td className={classes.tableCell}>{product.title}</td>
+              <td className={classes.tableCell}>{product.price.toLocaleString()}원</td>
+              <td className={classes.tableCell}>
+              <Link href={`/product/${product.id}`} passHref>
+                    <button className={classes.button}>상세보기</button>
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default RecentProducts;

--- a/AutumnShop/front/Autumnshop/pages/product/[id].js
+++ b/AutumnShop/front/Autumnshop/pages/product/[id].js
@@ -110,6 +110,27 @@ async function getProduct(setProduct, id, setIsFavorite){
   }
 }
 
+let isRequestingRecentProduct = false;
+
+async function addRecentProduct(id) {
+  if(isRequestingRecentProduct) return;
+  isRequestingRecentProduct = true;
+  try{
+    const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+    const addRecentProductResponse = await axios.post(`http://localhost:8080/recentProducts/${id}`, 
+      {},
+      {
+      headers: {
+        Authorization: `Bearer ${loginInfo.accessToken}`,
+      }
+    });
+  } catch (error) {
+    console.error("최근 본 상품에 추가되지 못했습니다.");
+  } finally {
+    isRequestingRecentProduct = false;
+  }
+}
+
 async function toggleFavorite(setIsFavorite, isFavorite, id) {
   try{
     const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
@@ -149,6 +170,8 @@ const ProductDetail = () => {
     if (!id) return; // id가 없으면 로딩하지 않음
 
     getProduct(setProduct, id, setIsFavorite);
+    
+    addRecentProduct(id);
   }, [id]);
 
   const handleToggleFavorite = async () => {

--- a/AutumnShop/front/Autumnshop/pages/product/[id].js
+++ b/AutumnShop/front/Autumnshop/pages/product/[id].js
@@ -110,6 +110,7 @@ async function getProduct(setProduct, id, setIsFavorite){
   }
 }
 
+// addRecentProduct 함수 한 번만 불러오도록 함
 let isRequestingRecentProduct = false;
 
 async function addRecentProduct(id) {

--- a/AutumnShop/src/main/java/com/example/AutumnMall/controller/FavoritesController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/controller/FavoritesController.java
@@ -1,11 +1,14 @@
 package com.example.AutumnMall.controller;
 
+import com.example.AutumnMall.domain.Product;
 import com.example.AutumnMall.security.jwt.util.IfLogin;
 import com.example.AutumnMall.security.jwt.util.LoginUserDto;
 import com.example.AutumnMall.service.FavoritesService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/favorites")
@@ -26,8 +29,14 @@ public class FavoritesController {
     }
 
     @GetMapping
-    public ResponseEntity<?> getFavorites(@IfLogin LoginUserDto loginUserDto){
-        return ResponseEntity.ok(favoritesService.getFavoritesProductIdByMember(loginUserDto.getMemberId()));
+    public ResponseEntity<List<Product>> getFavorites(@IfLogin LoginUserDto loginUserDto){
+        if(loginUserDto.getMemberId() == null) {
+            return ResponseEntity.badRequest().body(null);
+        }
+
+        List<Product> favoriteProducts = favoritesService.getFavoritesProductIdByMember(loginUserDto.getMemberId());
+
+        return ResponseEntity.ok(favoriteProducts);
     }
 
     @GetMapping("/{productId}")

--- a/AutumnShop/src/main/java/com/example/AutumnMall/controller/RecentProductController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/controller/RecentProductController.java
@@ -1,0 +1,39 @@
+package com.example.AutumnMall.controller;
+
+import com.example.AutumnMall.domain.RecentProduct;
+import com.example.AutumnMall.security.jwt.util.IfLogin;
+import com.example.AutumnMall.security.jwt.util.LoginUserDto;
+import com.example.AutumnMall.service.RecentProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/recentProducts")
+@RequiredArgsConstructor
+public class RecentProductController {
+    private final RecentProductService recentProductService;
+
+    // 최근 본 상품 추가
+    @PostMapping("/{productId}")
+    public ResponseEntity<String> addRecentProduct(@IfLogin LoginUserDto loginUserDto,
+                                                   @PathVariable Long productId){
+        if(loginUserDto.getMemberId() == null || productId == null){
+            return ResponseEntity.badRequest().body("최근 본 상품을 찾을 수 없습니다.");
+        }
+
+        recentProductService.addRecentProduct(loginUserDto.getMemberId(), productId);
+        return ResponseEntity.ok("최근 본 상품에 등록했습니다");
+    }
+
+ /*   @GetMapping
+    public ResponseEntity<List<RecentProduct>> getRecentProduct(@IfLogin LoginUserDto loginUserDto){
+        if(loginUserDto.getMemberId() == null) {
+            return ResponseEntity.badRequest().body(null);
+        }
+
+
+    } */
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/controller/RecentProductController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/controller/RecentProductController.java
@@ -1,5 +1,6 @@
 package com.example.AutumnMall.controller;
 
+import com.example.AutumnMall.domain.Product;
 import com.example.AutumnMall.domain.RecentProduct;
 import com.example.AutumnMall.security.jwt.util.IfLogin;
 import com.example.AutumnMall.security.jwt.util.LoginUserDto;
@@ -28,12 +29,18 @@ public class RecentProductController {
         return ResponseEntity.ok("최근 본 상품에 등록했습니다");
     }
 
- /*   @GetMapping
-    public ResponseEntity<List<RecentProduct>> getRecentProduct(@IfLogin LoginUserDto loginUserDto){
+    @GetMapping
+    public ResponseEntity<List<Product>> getRecentProduct(@IfLogin LoginUserDto loginUserDto){
         if(loginUserDto.getMemberId() == null) {
             return ResponseEntity.badRequest().body(null);
         }
 
+        List<Product> recentProducts = recentProductService.getRecentProducts(loginUserDto.getMemberId());
 
-    } */
+        if(recentProducts.isEmpty()){
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(recentProducts);
+    }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/domain/Member.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/domain/Member.java
@@ -99,6 +99,11 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<Favorites> favorites = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private List<RecentProduct> recentProducts = new ArrayList<>();
 }
 
 // User -----> Role

--- a/AutumnShop/src/main/java/com/example/AutumnMall/domain/Product.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/domain/Product.java
@@ -1,6 +1,7 @@
 package com.example.AutumnMall.domain;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -36,5 +37,9 @@ public class Product {
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<Favorites> favorites = new ArrayList<>();
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private List<RecentProduct> recentProducts = new ArrayList<>();
 }
 

--- a/AutumnShop/src/main/java/com/example/AutumnMall/domain/RecentProduct.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/domain/RecentProduct.java
@@ -1,0 +1,42 @@
+package com.example.AutumnMall.domain;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "recent_product", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "product_id"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecentProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JsonBackReference
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JsonBackReference
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @CreationTimestamp
+    @Column(name = "viewed_at", nullable = false)
+    private LocalDateTime viewedAt;
+
+    @Column(name = "product_id", insertable = false, updatable = false)
+    private Long productId;
+
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/repository/RecentProductRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/repository/RecentProductRepository.java
@@ -13,4 +13,7 @@ import java.util.Optional;
 public interface RecentProductRepository extends JpaRepository<RecentProduct, Long> {
     Optional<RecentProduct> findByMemberAndProduct(Member member, Product product);
     List<RecentProduct> findByMember(Member member);
+
+    // 멤버 ID를 기반으로 최근에 본 상품 조회
+    List<RecentProduct> findTop5ByMemberOrderByViewedAtDesc(Member member);
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/repository/RecentProductRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/repository/RecentProductRepository.java
@@ -1,0 +1,16 @@
+package com.example.AutumnMall.repository;
+
+import com.example.AutumnMall.domain.Member;
+import com.example.AutumnMall.domain.Product;
+import com.example.AutumnMall.domain.RecentProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RecentProductRepository extends JpaRepository<RecentProduct, Long> {
+    Optional<RecentProduct> findByMemberAndProduct(Member member, Product product);
+    List<RecentProduct> findByMember(Member member);
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/service/FavoritesService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/service/FavoritesService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -46,17 +47,15 @@ public class FavoritesService {
     }
 
     @Transactional(readOnly = true)
-    public List<Long> getFavoritesProductIdByMember(Long memberId){
+    public List<Product> getFavoritesProductIdByMember(Long memberId){
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("멤버를 찾을 수 없습니다."));
 
         List<Favorites> favorites = favoritesRepository.findByMember(member);
 
-        List<Long> productIds = new ArrayList<>();
-        for(Favorites favorite : favorites){
-            productIds.add(favorite.getProduct().getId());
-        }
-        return productIds;
+        return favorites.stream()
+                .map(Favorites::getProduct)
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/AutumnShop/src/main/java/com/example/AutumnMall/service/RecentProductService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/service/RecentProductService.java
@@ -1,0 +1,53 @@
+package com.example.AutumnMall.service;
+
+import com.example.AutumnMall.domain.Member;
+import com.example.AutumnMall.domain.Product;
+import com.example.AutumnMall.domain.RecentProduct;
+import com.example.AutumnMall.repository.MemberRepository;
+import com.example.AutumnMall.repository.ProductRepository;
+import com.example.AutumnMall.repository.RecentProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RecentProductService {
+    private final RecentProductRepository recentProductRepository;
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public void addRecentProduct(Long memberId, Long productId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("멤버를 찾을 수 없습니다."));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new RuntimeException("물품을 찾을 수 없습니다."));
+
+        Optional<RecentProduct> existing = recentProductRepository.findByMemberAndProduct(member, product);
+
+        if(existing.isPresent()){
+            RecentProduct recentProduct = existing.get();
+            recentProduct.setViewedAt(LocalDateTime.now());
+        }else {
+            List<RecentProduct> recentProducts = recentProductRepository.findByMember(member);
+
+            if(recentProducts.size() >= 5){
+                RecentProduct oldRecentProduct = recentProducts.get(0);
+                recentProductRepository.delete(oldRecentProduct);
+            }
+
+            RecentProduct newRecentProduct = RecentProduct.builder()
+                    .member(member)
+                    .product(product)
+                    .viewedAt(LocalDateTime.now())
+                    .build();
+            recentProductRepository.save(newRecentProduct);
+        }
+
+    }
+}


### PR DESCRIPTION
close #4
최근 본 상품 기능 추가 ( 내역 불러오기 x )
1. 로그인한 상태에서 상품의 '상세 보기'를 클릭할 시, 최근 본 상품들 테이블에 추가
2. 만약에, 최근 본 상품의 사이즈가 5가 넘는다면, 오래전에 본 상품 하나를 삭제하고, 최신에 본 상품을 추가
3. memberId를 통해서 add하기 때문에, 본 상품이 다를 수 밖에 없음


'내 정보' 페이지 에서 최근 본 상품을 조회할 수 있도록 함 ( 최대 5개)
1. 최근 본 상품에 추가할 때, 5개가 넘었을 경우 정렬하지 않고 삭제처리하여 본 기능에 맞지 않는 수행을 하였으므로,
    정렬하여 최근 본 상품을 삭제하도록 수정함
2. Product 리스트를 리턴하도록 하여 서비스단에서 멤버 id에 해당하는 데이터를 조회하여, Product만 리스트에 담아 리턴하도록 했음
3. Favorites (즐겨찾기) 기능에서 'getFavorites' 함수가 비효율적이어서 1번 처럼 리팩토링함.
4. 주석 추가 및 불필요한 주석 제거
 