### PR TITLE
내 정보 페이지 디자인 수정 완료

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/_app.js
+++ b/AutumnShop/front/Autumnshop/pages/_app.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { ThemeProvider } from "@mui/material/styles";
-import { Container } from "@mui/material"; // 수정된 코드
+import { Box } from "@mui/material"; // Container 대신 Box 사용
 import AppBar from "../components/AppBar";
 import { createTheme } from "@mui/material/styles";
 import Router from "next/router";
@@ -66,18 +66,28 @@ function MyApp({ Component, pageProps }) {
   return (
     <ThemeProvider theme={theme}>
       <AppBar />
-      <Container
+      <Box
         sx={{
-          minHeight: "calc(100% - 64px)", // 수정된 코드
-          minWidth: "767px", // 추가된 코드
-          paddingTop: "64px", // 수정된 코드
-          display: "flex", // 추가된 코드
-          justifyContent: "center", // 추가된 코드
-          alignItems: "center", // 추가된 코드
+          display: "flex",
+          minHeight: "100vh",
         }}
       >
-        <Component {...pageProps} />
-      </Container>
+
+        {/* Content Section */}
+        <Box
+          sx={{
+            flex: 1, // 콘텐츠 영역이 남은 공간을 차지하도록 설정
+            paddingTop: "64px", // AppBar 높이를 고려한 여백
+            padding: 4,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "flex-start", // 상단에 정렬되도록 설정
+          }}
+        >
+          <Component {...pageProps} />
+        </Box>
+      </Box>
     </ThemeProvider>
   );
 }

--- a/AutumnShop/front/Autumnshop/pages/addressSearch.js
+++ b/AutumnShop/front/Autumnshop/pages/addressSearch.js
@@ -1,15 +1,38 @@
 import React, { useEffect, useState } from "react";
 import { TextField, Button } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 
-const AddressSearch = ({ setRoadAddress, setZipCode, setDetailAddress, 
-  roadAddress, zipCode, detailAdd
+// css 적용
+const useStyles = makeStyles((theme) => ({
+  button: {
+    backgroundColor: "#000000",
+    color: "#ffffff",
+    '&:hover': {
+      backgroundColor: "#333",
+    },
+    marginBottom: theme.spacing(2),
+  },
+  textField: {
+    marginTop: theme.spacing(1),
+  },
+}));
+
+const AddressSearch = ({
+  setRoadAddress,
+  setZipCode,
+  setDetailAddress,
+  roadAddress,
+  zipCode,
+  detailAdd,
 }) => {
-      // 회원가입을 할 때의 경우와 내 정보를 수정하고자 할 때의 경우 두 가지를 구분 
-      const [address, setAddress] = useState({
-        roadAddress: roadAddress || "", 
-        zipCode: zipCode || "",
-      });
-      const [detailAddress, setLocalDetailAddress] = useState(detailAdd || "");
+  const classes = useStyles();
+
+  // 회원가입을 할 때의 경우와 내 정보를 수정하고자 할 때의 경우 두 가지를 구분 
+  const [address, setAddress] = useState({
+    roadAddress: roadAddress || "",
+    zipCode: zipCode || "",
+  });
+  const [detailAddress, setLocalDetailAddress] = useState(detailAdd || "");
 
   useEffect(() => {
     if (typeof window !== "undefined" && !window.Kakao) {
@@ -34,9 +57,9 @@ const AddressSearch = ({ setRoadAddress, setZipCode, setDetailAddress,
             setPostcodeLoaded(true);
           };
           document.body.appendChild(postcodeScript);
-      } else {
-        console.error("카카오 키를 불러오지 못했습니다.");
-      }
+        } else {
+          console.error("카카오 키를 불러오지 못했습니다.");
+        }
       };
       script.onerror = () => {
         console.error("카카오 SDK 로드 실패");
@@ -52,9 +75,8 @@ const AddressSearch = ({ setRoadAddress, setZipCode, setDetailAddress,
     setLocalDetailAddress(detailAdd || "");
   }, [roadAddress, zipCode, detailAdd]);
 
-  
-    const [kakaoLoaded, setKakaoLoaded] = useState(false);
-    const [postcodeLoaded, setPostcodeLoaded] = useState(false);
+  const [kakaoLoaded, setKakaoLoaded] = useState(false);
+  const [postcodeLoaded, setPostcodeLoaded] = useState(false);
 
   const handleAddressSearch = () => {
     if (!kakaoLoaded || !postcodeLoaded) {
@@ -87,7 +109,11 @@ const AddressSearch = ({ setRoadAddress, setZipCode, setDetailAddress,
 
   return (
     <div>
-      <Button variant="contained" onClick={handleAddressSearch}>
+      <Button
+        variant="contained"
+        className={classes.button}
+        onClick={handleAddressSearch}
+      >
         주소 검색
       </Button>
       <TextField
@@ -96,6 +122,7 @@ const AddressSearch = ({ setRoadAddress, setZipCode, setDetailAddress,
         fullWidth
         margin="normal"
         InputProps={{ readOnly: true }}
+        className={classes.textField}
       />
       <TextField
         label="도로명 주소"
@@ -103,6 +130,7 @@ const AddressSearch = ({ setRoadAddress, setZipCode, setDetailAddress,
         fullWidth
         margin="normal"
         InputProps={{ readOnly: true }}
+        className={classes.textField}
       />
       <TextField
         label="상세 주소"
@@ -111,6 +139,7 @@ const AddressSearch = ({ setRoadAddress, setZipCode, setDetailAddress,
         fullWidth
         margin="normal"
         placeholder="상세 주소를 입력하세요"
+        className={classes.textField}
       />
     </div>
   );

--- a/AutumnShop/front/Autumnshop/pages/mypage/getFavorites.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/getFavorites.js
@@ -5,60 +5,61 @@ import Link from "next/link";
 const useStyles = makeStyles(() => ({
   container: {
     padding: "20px",
-    border: "1px solid #ccc",
+    border: "2px solid #333",
     borderRadius: "8px",
-    backgroundColor: "#f8f8f8",
+    backgroundColor: "#ffffff",
     textAlign: "center",
     maxWidth: "800px",
     margin: "20px auto",
+    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
   },
   table: {
     width: "100%",
     borderCollapse: "collapse",
   },
   tableHeader: {
-    backgroundColor: "#3f51b5",
-    color: "#fff",
+    backgroundColor: "#000000",
+    color: "#ffffff",
     fontWeight: "bold",
     textAlign: "center",
-    padding: "12px",
+    padding: "14px",
   },
   tableCell: {
-    border: "1px solid #ddd",
-    padding: "12px",
+    border: "2px solid #ddd",
+    padding: "14px",
     textAlign: "center",
+    color: "#333",
   },
   tableRow: {
     "&:hover": {
-      backgroundColor: "#f1f1f1",
+      backgroundColor: "#f9f9f9",
     },
   },
   button: {
-    padding: "8px 16px",
-    fontSize: "14px",
+    padding: "10px 20px",
+    fontSize: "16px",
     fontWeight: "bold",
-    color: "#fff",
-    backgroundColor: "#007BFF",
+    color: "#ffffff",
+    backgroundColor: "#000000",
     border: "none",
-    borderRadius: "4px",
+    borderRadius: "6px",
     cursor: "pointer",
     transition: "background-color 0.3s ease, transform 0.2s ease",
     "&:hover": {
-      backgroundColor: "#0056b3",
+      backgroundColor: "#333",
       transform: "scale(1.05)",
     },
     "&:active": {
-      backgroundColor: "#003f7f",
+      backgroundColor: "#222",
       transform: "scale(0.95)",
     },
   },
 }));
 
-// getFavorites 함수 한 번만 불러올 수 있도록 함
 let isRequestingFavorites = false;
 
 async function getFavorites(setFavorites) {
-  if(isRequestingFavorites) return;
+  if (isRequestingFavorites) return;
   isRequestingFavorites = true;
   try {
     const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
@@ -74,9 +75,8 @@ async function getFavorites(setFavorites) {
         Authorization: `Bearer ${loginInfo.accessToken}`,
       },
     });
-    console.log(getFavoritesResponse);
 
-    if (!getFavoritesResponse.ok){
+    if (!getFavoritesResponse.ok) {
       throw new error;
     }
 
@@ -100,7 +100,7 @@ const GetFavorites = () => {
   if (!favorites.length) {
     return (
       <div className={classes.container}>
-        <h3>즐겨찾기 목록</h3>
+        <h2>즐겨찾기 목록</h2>
         <p>즐겨찾기 목록이 비어있습니다.</p>
       </div>
     );
@@ -108,7 +108,7 @@ const GetFavorites = () => {
 
   return (
     <div className={classes.container}>
-      <h3>즐겨찾기 목록</h3>
+      <h2>즐겨찾기 목록</h2>
       <table className={classes.table}>
         <thead>
           <tr>
@@ -125,14 +125,19 @@ const GetFavorites = () => {
                 <img
                   src={product.imageUrl}
                   alt={product.title}
-                  style={{ width: "100px", height: "100px", objectFit: "cover", borderRadius: "8px" }}
+                  style={{
+                    width: "100px",
+                    height: "100px",
+                    objectFit: "cover",
+                    borderRadius: "8px",
+                  }}
                 />
               </td>
               <td className={classes.tableCell}>{product.title}</td>
               <td className={classes.tableCell}>{product.price.toLocaleString()}원</td>
               <td className={classes.tableCell}>
                 <Link href={`/product/${product.id}`} passHref>
-                    <button className={classes.button}>상세보기</button>
+                  <button className={classes.button}>상세보기</button>
                 </Link>
               </td>
             </tr>

--- a/AutumnShop/front/Autumnshop/pages/mypage/index.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/index.js
@@ -1,9 +1,98 @@
 import React, { useEffect, useState } from "react";
-import { Container, Typography, Box, Button } from "@mui/material";
-import Link from "next/link";
+import { Box, Button, Typography, Divider, TextField } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import MileageHistory from "./mileageHistory";
+import PassCheck from "./passCheck";
+import RecentProducts from "./recentProducts";
+import GetFavorites from "./getFavorites";
+import PasswordEdit from "./passwordEdit";
+
+const useStyles = makeStyles({
+  sidebar: {
+    width: "250px",
+    backgroundColor: "#ffffff",
+    display: "flex",
+    flexDirection: "column",
+    padding: "16px",
+    boxShadow: "2px 0 5px rgba(0, 0, 0, 0.1)",
+    height: "100vh",
+  },
+  content: {
+    flex: 1,
+    padding: "24px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    backgroundColor: "#fff",
+    borderRadius: "8px",
+    boxShadow: "0 0 10px rgba(0, 0, 0, 0.1)",
+    height: "100vh",
+  },
+  title: {
+    marginBottom: "16px",
+    fontWeight: 700,
+    textAlign: "center",
+    color: "#333",
+  },
+  button: {
+    marginBottom: "8px",
+    justifyContent: "flex-start",
+    fontWeight: 600,
+    color: "#000",
+    backgroundColor: "transparent",
+    "&:hover": { backgroundColor: "#808080" },
+  },
+  activeButton: {
+    color: "#fff",
+    backgroundColor: "#000000",
+    "&:hover": {
+      backgroundColor: "#000000",
+    },
+  },
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    width: "100%",
+    padding: "16px 0",
+    gap: 2,
+  },
+  sectionText: {
+    marginBottom: "16px",
+  },
+  textField: {
+    width: "100%",
+    marginBottom: "16px", 
+    borderRadius: "4px",
+    border: "1px solid #ddd",
+    padding: "10px",
+    backgroundColor: "#f9f9f9",
+    "& .MuiInputBase-root": {
+      padding: "0",
+    },
+    "& .MuiInputLabel-root": {
+      fontWeight: "700",
+      fontSize: "1rem", 
+      color: "#333", 
+    },
+    "& .MuiInputBase-input": {
+      color: "#333", 
+      fontWeight: "700", 
+    },
+  },
+  divider: {
+    marginBottom: "24px", 
+    width: "100%",
+    borderColor: "#000", 
+    borderWidth: "2px", 
+  },
+});
 
 const MyPage = () => {
   const [userInfo, setUserInfo] = useState(null);
+  const [activeSection, setActiveSection] = useState("profile");
+  const classes = useStyles();
 
   useEffect(() => {
     const getUserInfo = async () => {
@@ -29,98 +118,146 @@ const MyPage = () => {
         const data = await response.json();
         setUserInfo(data);
       } catch (error) {
-        console.error(error);
-        window.location.href = "/login";
+        console.log("유저 정보를 불러오는 데 실패했습니다.", error);
       }
     };
 
     getUserInfo();
   }, []);
 
+  const renderSection = () => {
+    switch (activeSection) {
+      case "profile":
+        return (
+          <Box className={classes.section}>
+            <TextField
+              label="이름"
+              value={userInfo.name}
+              className={classes.textField}
+              variant="outlined"
+              InputProps={{ readOnly: true }}
+            />
+            <TextField
+              label="이메일"
+              value={userInfo.email}
+              className={classes.textField}
+              variant="outlined"
+              InputProps={{ readOnly: true }}
+            />
+            <TextField
+              label="생년월일"
+              value={`${userInfo.birthYear}년 ${userInfo.birthMonth}월 ${userInfo.birthDay}일`}
+              className={classes.textField}
+              variant="outlined"
+              InputProps={{ readOnly: true }}
+            />
+            <TextField
+              label="성별"
+              value={userInfo.gender === "M" ? "남자" : "여자"}
+              className={classes.textField}
+              variant="outlined"
+              InputProps={{ readOnly: true }}
+            />
+            <TextField
+              label="전화번호"
+              value={userInfo.phone}
+              className={classes.textField}
+              variant="outlined"
+              InputProps={{ readOnly: true }}
+            />
+            <TextField
+              label="주소"
+              value={`${userInfo.roadAddress} (${userInfo.zipCode})`}
+              className={classes.textField}
+              variant="outlined"
+              InputProps={{ readOnly: true }}
+            />
+          </Box>
+        );
+      case "mileage":
+        return <MileageHistory />;
+      case "favorites":
+        return <GetFavorites />;
+      case "recent":
+        return <RecentProducts />
+      case "check":
+        return <PassCheck />
+      case "edit" :
+        return <PasswordEdit />
+      default:
+        return null;
+    }
+  };
+
   if (!userInfo) {
     return <div>Loading...</div>;
   }
 
   return (
-    <Container
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: "100vh",
-      }}
-    >
-      <h1>MyPage</h1>
-      <p>MyPage 페이지입니다.</p>
-      <Box sx={{ textAlign: "center" }}>
-        <Typography variant="h5">이름: {userInfo.name}</Typography>
-        <Typography variant="h5">이메일: {userInfo.email}</Typography>
-        <Typography variant="h5">
-          생년월일: {userInfo.birthYear}년 {userInfo.birthMonth}월{" "}
-          {userInfo.birthDay}일
+    <Box sx={{ display: "flex", width: "100%", minHeight: "100vh", flexDirection: "row" }}>
+      {/* 사이드바 */}
+      <Box className={classes.sidebar}>
+        <Typography variant="h6" sx={{ fontWeight: 600, marginBottom: 3 }}>
+          마이페이지
         </Typography>
-        <Typography variant="h5">
-          성별: {userInfo.gender === "M" ? "남자" : "여자"}
-        </Typography>
-        <Typography variant="h5">마일리지: {userInfo.totalMileage}</Typography>
-        <div>
-          <Link href={`/mypage/mileageHistory`}>
-          <Button
-          variant="contained"
-          color="primary"
-          sx={{ marginTop: 2}}
-          >
-            마일리지 내역 확인
-            </Button>
-            </Link>
-            </div>
-        <div>
-          <Link href={`/mypage/passwordEdit`} passHref>
         <Button
-        variant="contained"
-        color="primary"
-        sx={{ marginTop: 2}}
+          variant={activeSection === "profile" ? "contained" : "text"}
+          onClick={() => setActiveSection("profile")}
+          className={`${classes.button} ${activeSection === "profile" ? classes.activeButton : ""}`}
         >
-          비밀번호 변경
-          </Button>
-          </Link>
-          </div>
-        <div>
-        <Link href={`/mypage/getFavorites`} passHref>
-        <Button
-            variant="contained"
-            color="primary"
-            sx={{ marginTop: 2 }}
-          >
-            즐겨찾기 목록 보기
-          </Button>
-          </Link>
-        </div>
-        <div>
-          <Link href={`/mypage/recentProducts`} passHref>
-          <Button
-            variant="contained"
-            color="primary"
-            sx={{ marginTop : 2}}
-            >
-              최근 본 상품 보기
-            </Button>
-            </Link>
-        </div>
-        <div>
-          <Link href={`/mypage/passCheck`} passHref>
-        <Button 
-          variant="contained" 
-          color="primary" 
-          sx={{ marginTop: 2 }}
-        >
-          수정하기
+          내 정보
         </Button>
-        </Link>
-        </div>
+        <Button
+          variant={activeSection === "mileage" ? "contained" : "text"}
+          onClick={() => setActiveSection("mileage")}
+          className={`${classes.button} ${activeSection === "mileage" ? classes.activeButton : ""}`}
+        >
+          마일리지 내역
+        </Button>
+        <Button
+          variant={activeSection === "favorites" ? "contained" : "text"}
+          onClick={() => setActiveSection("favorites")}
+          className={`${classes.button} ${activeSection === "favorites" ? classes.activeButton : ""}`}
+        >
+          즐겨찾기
+        </Button>
+        <Button
+          variant={activeSection === "recent" ? "contained" : "text"}
+          onClick={() => setActiveSection("recent")}
+          className={`${classes.button} ${activeSection === "recent" ? classes.activeButton : ""}`}
+        >
+          최근 본 상품
+        </Button>
+        <Button
+          variant={activeSection === "edit" ? "contained" : "text"}
+          onClick={() => setActiveSection("edit")}
+          className={`${classes.button} ${activeSection === "edit" ? classes.activeButton : ""}`}
+        >
+          비밀번호 수정
+        </Button>
+        <Button
+          variant={activeSection === "check" ? "contained" : "text"}
+          onClick={() => setActiveSection("check")}
+          className={`${classes.button} ${activeSection === "check" ? classes.activeButton : ""}`}
+        >
+          개인정보 수정
+        </Button>
       </Box>
-    </Container>
+
+      {/* 내용 */}
+      <Box className={classes.content}>
+        <Typography variant="h4" className={classes.title}>
+          {activeSection === "profile" && "내 정보"}
+          {activeSection === "mileage" && "마일리지 내역"}
+          {activeSection === "favorites" && "즐겨찾기 목록"}
+          {activeSection === "recent" && "최근 본 상품"}
+          {activeSection === "edit" && "비밀번호 수정"}
+          {activeSection === "check" && "개인정보 수정"}
+        </Typography>
+        <Divider className={classes.divider} />
+        {renderSection()}
+      </Box>
+    </Box>
   );
 };
 

--- a/AutumnShop/front/Autumnshop/pages/mypage/mileageHistory.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/mileageHistory.js
@@ -6,26 +6,32 @@ const useStyles = makeStyles(() => ({
     tableContainer: {
         width: "80%",
         margin: "20px auto",
-        padding: "20px",
-        border: "1px solid #ccc",
+        padding: "30px",
+        border: "3px solid #000",
         borderRadius: "8px",
-        backgroundColor: "#f8f8f8",
+        backgroundColor: "#fff",
+        color: "#000",
         boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+        textAlign: "center",
     },
     table: {
         width: "100%",
         borderCollapse: "collapse",
+        fontSize: "16px",
     },
     tableHeader: {
-        backgroundColor: "#3f51b5",
-        color: "#fff",
+        backgroundColor: "#f4f4f4",
+        color: "#000",
         textAlign: "center",
         fontWeight: "bold",
+        borderBottom: "3px solid #000",
+        padding: "15px",
     },
     tableCell: {
-        padding: "12px",
-        borderBottom: "1px solid #ddd",
+        padding: "16px",
+        borderBottom: "2px solid #000",
         textAlign: "center",
+        fontSize: "16px",
     },
     tableRow: {
         "&:hover": {
@@ -33,41 +39,47 @@ const useStyles = makeStyles(() => ({
         },
     },
     totalContainer: {
-        marginTop: "20px",
-        padding: "10px",
-        backgroundColor: "#e1f5fe",
+        marginTop: "30px",
+        padding: "15px",
+        backgroundColor: "#f4f4f4",
         borderRadius: "8px",
-        fontSize: "18px",
+        fontSize: "20px",
         fontWeight: "bold",
         textAlign: "center",
+        color: "#000",
+        border: "2px solid #000",
     },
     paginationContainer: {
         display: "flex",
         justifyContent: "center",
         alignItems: "center",
-        marginTop: "20px",
-        gap: "10px",
+        marginTop: "30px",
+        gap: "15px",
     },
     paginationButton: {
-        padding: "8px 16px",
-        border: "1px solid #3f51b5",
+        padding: "10px 20px",
+        border: "2px solid #000",
         borderRadius: "4px",
         backgroundColor: "#fff",
         cursor: "pointer",
-        color: "#3f51b5",
+        color: "#000",
         fontWeight: "bold",
         "&:disabled": {
             backgroundColor: "#e0e0e0",
             cursor: "not-allowed",
         },
+        "&:hover": {
+            backgroundColor: "#f1f1f1",
+        },
     },
     currentPage: {
         fontWeight: "bold",
+        color: "#000",
+        fontSize: "18px",
     },
 }));
 
-
-// 현재 페이지에 따라서 마일리지 내역 출력 (size : 10)
+// 현재 페이지에 따라서 마일리지 내역 출력 (size: 10)
 async function getMileageHistory(setMileageHistory, page, setTotalPages) {
     try {
         const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
@@ -142,7 +154,7 @@ const mileageHistory = () => {
 
     return (
         <div className={classes.tableContainer}>
-            <h3>마일리지 히스토리</h3>
+            <h2>마일리지 히스토리</h2>
             <table className={classes.table}>
                 <thead>
                     <tr className={classes.tableHeader}>

--- a/AutumnShop/front/Autumnshop/pages/mypage/myWrite.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/myWrite.js
@@ -23,18 +23,54 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: "500px",
     height: "100%",
     margin: "0 auto",
+    backgroundColor: "#ffffff",
+    padding: "20px",
+    borderRadius: "8px",
+    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
   },
   form: {
     display: "flex",
     flexDirection: "column",
     width: "100%",
   },
+  button: {
+    marginTop: theme.spacing(2),
+    backgroundColor: "#000000",
+    color: "#ffffff",
+    '&:hover': {
+      backgroundColor: "#333",
+    },
+  },
+  textField: {
+    marginBottom: theme.spacing(2),
+    '& .MuiOutlinedInput-root': {
+      '& fieldset': {
+        borderColor: "#ccc",
+      },
+      '&:hover fieldset': {
+        borderColor: "#888",
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: "#888",
+      },
+    },
+    '& .MuiInputLabel-root': {
+      color: "#888",
+    },
+    '& .MuiInputLabel-root.Mui-focused': {
+      color: "#888",
+    },
+  },
+  errorMessage: {
+    color: "red",
+    marginTop: "10px",
+  },
 }));
 
-const myWriteForm = () => {
+const MyWriteForm = () => {
   const classes = useStyles();
 
-  async function getMember(){
+  async function getMember() {
     const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
     const getMemberResponse = await fetch(
       "http://localhost:8080/members/info",
@@ -46,8 +82,8 @@ const myWriteForm = () => {
       }
     );
 
-    if(!getMemberResponse.ok){
-      throw new error;
+    if (!getMemberResponse.ok) {
+      throw new Error();
     }
 
     const data = await getMemberResponse.json();
@@ -59,13 +95,17 @@ const myWriteForm = () => {
     setRoadAddress(data.roadAddress);
     setDetailAddress(data.detailAddress);
 
-      // 생년월일 YYYY-MM-DD 형식으로 변환
-    setBirthDate(`${data.birthYear}-${String(data.birthMonth).padStart(2, "0")}-${String(data.birthDay).padStart(2, "0")}`);
+    // 생년월일 YYYY-MM-DD 형식으로 변환
+    setBirthDate(
+      `${data.birthYear}-${String(data.birthMonth).padStart(2, "0")}-${String(
+        data.birthDay
+      ).padStart(2, "0")}`
+    );
   }
 
   useEffect(() => {
     getMember();
-  }, [])
+  }, []);
 
   // 상태 설정 추가
   const [email, setEmail] = useState("");
@@ -88,7 +128,7 @@ const myWriteForm = () => {
 
     // 전화번호 형식 확인
     const phonePattern = /^(010|031|032)-\d{3,4}-\d{4}$/;
-    if(!phonePattern.test(phone)){
+    if (!phonePattern.test(phone)) {
       alert("전화번호 형식이 올바르지 않습니다!");
       return;
     }
@@ -96,7 +136,7 @@ const myWriteForm = () => {
       alert("상세 주소를 입력해주세요!");
       return;
     }
-    // 생년/월/일별로 분리 
+    // 생년/월/일별로 분리
     const [birthYear, birthMonth, birthDay] = birthDate.split("-");
 
     const memberSignupDto = {
@@ -114,17 +154,18 @@ const myWriteForm = () => {
     };
 
     try {
-      console.log(memberSignupDto);
       const response = await fetch(
-        "http://localhost:8080/members/write",{
+        "http://localhost:8080/members/write",
+        {
           method: "PATCH",
           headers: {
             "Content-type": "application/json",
           },
           body: JSON.stringify(memberSignupDto),
-        });
-      if (response.status === 200 || response.status == 201) {
-        console.log(memberSignupDto);
+        }
+      );
+      if (response.status === 200 || response.status === 201) {
+        alert("정보 수정이 성공적으로 완료되었습니다!");
         window.location.href = "http://localhost:3000/mypage";
       }
     } catch (error) {
@@ -147,6 +188,7 @@ const myWriteForm = () => {
           required
           value={name}
           InputProps={{ readOnly: true }}
+          className={classes.textField}
         />
         <TextField
           label="이메일"
@@ -157,6 +199,7 @@ const myWriteForm = () => {
           required
           value={email}
           InputProps={{ readOnly: true }}
+          className={classes.textField}
         />
         <TextField
           label="생년월일"
@@ -170,6 +213,7 @@ const myWriteForm = () => {
           required
           value={birthDate}
           onChange={(e) => setBirthDate(e.target.value)}
+          className={classes.textField}
         />
 
         <FormControl fullWidth variant="outlined" margin="normal" required>
@@ -180,34 +224,35 @@ const myWriteForm = () => {
           </Select>
         </FormControl>
         <TextField
-        label="전화번호"
-        type="text"
-        variant="outlined"
-        margin="normal"
-        fullWidth
-        required
-        placeholder="010-0000-0000"
-        value={phone}
-        onChange={(e) => setPhone(e.target.value)}
-        inputProps={{
-          pattern: "^(010|031|032)-\\d{3,4}-\\d{4}$",
-        }}
-        helperText="형식: 010-0000-0000"
-      />
+          label="전화번호"
+          type="text"
+          variant="outlined"
+          margin="normal"
+          fullWidth
+          required
+          placeholder="010-0000-0000"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          inputProps={{
+            pattern: "^(010|031|032)-\\d{3,4}-\\d{4}$",
+          }}
+          helperText="형식: 010-0000-0000"
+          className={classes.textField}
+        />
 
-        <AddressSearch 
-        setRoadAddress={setRoadAddress}
-        setZipCode={setZipCode}
-        setDetailAddress={setDetailAddress}
-        roadAddress={roadAddress}
-        zipCode={zipCode}
-        detailAdd={detailAddress}/>
-
+        <AddressSearch
+          setRoadAddress={setRoadAddress}
+          setZipCode={setZipCode}
+          setDetailAddress={setDetailAddress}
+          roadAddress={roadAddress}
+          zipCode={zipCode}
+          detailAdd={detailAddress}
+        />
 
         <Button
           type="submit"
           variant="contained"
-          color="primary"
+          className={classes.button}
           size="large"
           fullWidth
         >
@@ -218,4 +263,4 @@ const myWriteForm = () => {
   );
 };
 
-export default myWriteForm;
+export default MyWriteForm;

--- a/AutumnShop/front/Autumnshop/pages/mypage/passCheck.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/passCheck.js
@@ -1,70 +1,102 @@
 import React, { useState } from "react";
 import {
-    Container,
-    Typography,
-    TextField,
-    Button,
-  } from "@mui/material";
+  Container,
+  Typography,
+  TextField,
+  Button,
+} from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
 const useStyles = makeStyles((theme) => ({
-    container: {
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      justifyContent: "center",
-      width: "100%",
-      maxWidth: "500px",
-      height: "100%",
-      margin: "0 auto",
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    maxWidth: "500px",
+    height: "100%",
+    margin: "0 auto",
+    backgroundColor: "#ffffff",
+    padding: "20px",
+    borderRadius: "8px",
+    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+  },
+  form: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+  },
+  button: {
+    marginTop: theme.spacing(2),
+    backgroundColor: "#000000",
+    color: "#ffffff",
+    '&:hover': {
+      backgroundColor: "#333",
     },
-    form: {
-      display: "flex",
-      flexDirection: "column",
-      width: "100%",
+  },
+  textField: {
+    marginBottom: theme.spacing(2),
+    '& .MuiOutlinedInput-root': {
+      '& fieldset': {
+        borderColor: "#ccc",
+      },
+      '&:hover fieldset': {
+        borderColor: "#888",
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: "#888",
+      },
     },
-    button: {
-      marginTop: theme.spacing(2),
+    '& .MuiInputLabel-root': {
+      color: "#888",
     },
-  }));
+    '& .MuiInputLabel-root.Mui-focused': {
+      color: "#888",
+    },
+  },
+  errorMessage: {
+    color: "red",
+    marginTop: "10px",
+  },
+}));
 
 const passCheck = () => {
-    const classes = useStyles();
+  const classes = useStyles();
 
-    const [password, setPassword] = useState("");
-    const [errorMessage, setErrorMessage] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
 
-      const passwordCheck = async () => {
-        try{
-            const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
-             const response = await fetch(
-                 "http://localhost:8080/members/checkPassword",
-                 {
-                    method: "POST",
-                    headers: {
-                        "Content-type" : "application/json",
-                        Authorization: `Bearer ${loginInfo.accessToken}`,
-                    },
-                    body: JSON.stringify({ password }),
-                 }
-             );
-             if(response.ok){
-                const data = await response.json();
-                if(data){
-                  window.location.href = "http://localhost:3000/mypage/myWrite";
-                }
-                else{
-                  throw new error;
-                }
-             }else{
-                throw new error;
-             }
-        }catch (error){
-            setErrorMessage("비밀번호가 일치하지 않습니다.");
+  const passwordCheck = async () => {
+    try {
+      const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+      const response = await fetch(
+        "http://localhost:8080/members/checkPassword",
+        {
+          method: "POST",
+          headers: {
+            "Content-type": "application/json",
+            Authorization: `Bearer ${loginInfo.accessToken}`,
+          },
+          body: JSON.stringify({ password }),
         }
+      );
+      if (response.ok) {
+        const data = await response.json();
+        if (data) {
+          window.location.href = "http://localhost:3000/mypage/myWrite";
+        } else {
+          throw new Error();
+        }
+      } else {
+        throw new Error();
       }
+    } catch (error) {
+      setErrorMessage("비밀번호가 일치하지 않습니다.");
+    }
+  };
 
-    return (
+  return (
     <Container className={classes.container}>
       <Typography variant="h6">비밀번호를 입력해주세요.</Typography>
       <form className={classes.form} noValidate autoComplete="off">
@@ -76,16 +108,15 @@ const passCheck = () => {
           onChange={(e) => setPassword(e.target.value)}
           fullWidth
           required
-          margin="normal"
+          className={classes.textField}
         />
         {errorMessage && (
-          <Typography color="error" variant="body2" style={{ marginTop: "10px" }}>
+          <Typography className={classes.errorMessage} variant="body2">
             {errorMessage}
           </Typography>
         )}
         <Button
           variant="contained"
-          color="primary"
           className={classes.button}
           onClick={passwordCheck}
         >
@@ -93,8 +124,7 @@ const passCheck = () => {
         </Button>
       </form>
     </Container>
-    )
-
-}
+  );
+};
 
 export default passCheck;

--- a/AutumnShop/front/Autumnshop/pages/mypage/passwordEdit.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/passwordEdit.js
@@ -12,6 +12,10 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: "500px",
     height: "100%",
     margin: "0 auto",
+    backgroundColor: "#ffffff",
+    padding: "20px",
+    borderRadius: "8px",
+    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
   },
   form: {
     display: "flex",
@@ -20,6 +24,35 @@ const useStyles = makeStyles((theme) => ({
   },
   button: {
     marginTop: theme.spacing(2),
+    backgroundColor: "#000000",
+    color: "#ffffff",
+    '&:hover': {
+      backgroundColor: "#333",
+    },
+  },
+  textField: {
+    marginBottom: theme.spacing(2),
+    '& .MuiOutlinedInput-root': {
+      '& fieldset': {
+        borderColor: "#ccc",
+      },
+      '&:hover fieldset': {
+        borderColor: "#888",
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: "#888",
+      },
+    },
+    '& .MuiInputLabel-root': {
+      color: "#888",
+    },
+    '& .MuiInputLabel-root.Mui-focused': {
+      color: "#888",
+    },
+  },
+  errorMessage: {
+    color: "red",
+    marginTop: "10px",
   },
 }));
 
@@ -80,7 +113,7 @@ const PasswordChange = () => {
           onChange={(e) => setOldPassword(e.target.value)}
           fullWidth
           required
-          margin="normal"
+          className={classes.textField}
         />
         <TextField
           label="새 비밀번호"
@@ -90,7 +123,7 @@ const PasswordChange = () => {
           onChange={(e) => setNewPassword(e.target.value)}
           fullWidth
           required
-          margin="normal"
+          className={classes.textField}
         />
         <TextField
           label="새 비밀번호 확인"
@@ -100,16 +133,15 @@ const PasswordChange = () => {
           onChange={(e) => setConfirmPassword(e.target.value)}
           fullWidth
           required
-          margin="normal"
+          className={classes.textField}
         />
         {errorMessage && (
-          <Typography color="error" variant="body2" style={{ marginTop: "10px" }}>
+          <Typography className={classes.errorMessage} variant="body2">
             {errorMessage}
           </Typography>
         )}
         <Button
           variant="contained"
-          color="primary"
           className={classes.button}
           onClick={handlePasswordChange}
         >

--- a/AutumnShop/front/Autumnshop/pages/mypage/recentProducts.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/recentProducts.js
@@ -5,50 +5,52 @@ import Link from "next/link";
 const useStyles = makeStyles(() => ({
   container: {
     padding: "20px",
-    border: "1px solid #ccc",
+    border: "2px solid #333",
     borderRadius: "8px",
-    backgroundColor: "#f8f8f8",
+    backgroundColor: "#ffffff",
     textAlign: "center",
     maxWidth: "800px",
     margin: "20px auto",
+    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
   },
   table: {
     width: "100%",
     borderCollapse: "collapse",
   },
   tableHeader: {
-    backgroundColor: "#3f51b5",
-    color: "#fff",
+    backgroundColor: "#000000",
+    color: "#ffffff",
     fontWeight: "bold",
     textAlign: "center",
-    padding: "12px",
+    padding: "14px",
   },
   tableCell: {
-    border: "1px solid #ddd",
-    padding: "12px",
+    border: "2px solid #ddd",
+    padding: "14px",
     textAlign: "center",
+    color: "#333",
   },
   tableRow: {
     "&:hover": {
-      backgroundColor: "#f1f1f1",
+      backgroundColor: "#f9f9f9",
     },
   },
   button: {
-    padding: "8px 16px",
-    fontSize: "14px",
+    padding: "10px 20px",
+    fontSize: "16px",
     fontWeight: "bold",
-    color: "#fff",
-    backgroundColor: "#007BFF",
+    color: "#ffffff",
+    backgroundColor: "#000000",
     border: "none",
-    borderRadius: "4px",
+    borderRadius: "6px",
     cursor: "pointer",
     transition: "background-color 0.3s ease, transform 0.2s ease",
     "&:hover": {
-      backgroundColor: "#0056b3",
+      backgroundColor: "#333",
       transform: "scale(1.05)",
     },
     "&:active": {
-      backgroundColor: "#003f7f",
+      backgroundColor: "#222",
       transform: "scale(0.95)",
     },
   },
@@ -83,7 +85,7 @@ async function getRecentProducts(setRecentProducts) {
     const data = await getRecentProductsResponse.json();
 
     if(!data.length)
-        alert("최근 본 상품이 없습니다!");
+      alert("최근 본 상품이 없습니다!");
 
     // 최근 본 상품 목록을 최신 순으로 정렬
     setRecentProducts(data.reverse()); // reverse()로 최신 순 정렬
@@ -105,7 +107,7 @@ const RecentProducts = () => {
   if (!recentProducts.length) {
     return (
       <div className={classes.container}>
-        <h3>최근 본 상품</h3>
+        <h2>최근 본 상품</h2>
         <p>최근 본 상품이 없습니다.</p>
       </div>
     );
@@ -113,7 +115,7 @@ const RecentProducts = () => {
 
   return (
     <div className={classes.container}>
-      <h3>최근 본 상품</h3>
+      <h2>최근 본 상품</h2>
       <table className={classes.table}>
         <thead>
           <tr>
@@ -125,22 +127,24 @@ const RecentProducts = () => {
         </thead>
         <tbody>
           {recentProducts.map((product) => (
-            <tr
-              key={product.id}
-              className={classes.tableRow}
-            >
+            <tr key={product.id} className={classes.tableRow}>
               <td className={classes.tableCell}>
                 <img
                   src={product.imageUrl}
                   alt={product.title}
-                  style={{ width: "100px", height: "100px", objectFit: "cover", borderRadius: "8px" }}
+                  style={{
+                    width: "100px",
+                    height: "100px",
+                    objectFit: "cover",
+                    borderRadius: "8px",
+                  }}
                 />
               </td>
               <td className={classes.tableCell}>{product.title}</td>
               <td className={classes.tableCell}>{product.price.toLocaleString()}원</td>
               <td className={classes.tableCell}>
-              <Link href={`/product/${product.id}`} passHref>
-                    <button className={classes.button}>상세보기</button>
+                <Link href={`/product/${product.id}`} passHref>
+                  <button className={classes.button}>상세보기</button>
                 </Link>
               </td>
             </tr>


### PR DESCRIPTION
1. '마일리지 내역 확인, 비밀번호 변경, 즐겨찾기 목록 보기, 최근 본 상품 보기, 수정하기' 가 해당됨.
2. 전체적으로 배경을 하얗게, 표시되는 건 까맣게, 다른 색깔들은 회색으로 하였음
3. 기존에 내 정보 페이지에서 버튼으로 이동되던 것을, 레이아웃을 두 개로 나눔
- 왼쪽은 사이드바로, 각 사이드에 해당하는 것을 누르면 오른쪽이 그에 맞게 렌더링 됨
4. 전체적인 레이아웃을 수정하였으므로, 카트목록, 구매목록의 디자인이 이상하니 추후에 개발 예정