### PR TITLE
리프레쉬 재발급 시간 수정

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/_app.js
+++ b/AutumnShop/front/Autumnshop/pages/_app.js
@@ -55,7 +55,7 @@ function MyApp({ Component, pageProps }) {
           Router.push("/");
         }
       }
-    }, 10 * 60 * 1000); // 10분마다 실행
+    }, 10 * 1000); // 10분마다 실행
 
     // 컴포넌트가 언마운트 될 때 인터벌을 정리
     return () => {


### PR DESCRIPTION
리프레쉬 재발급이 10 * 60 * 1000으로 길게 설정되어 기존의 리프레쉬 토큰 재발급과 맞지않아 로그인/아웃 상태에 영향 가던 점 수정