### PR TITLE
#60 장바구니 목록, 주문 정보, 구매 목록 css 변경

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/cartItems.js
+++ b/AutumnShop/front/Autumnshop/pages/cartItems.js
@@ -12,24 +12,32 @@ const useStyles = makeStyles((theme) => ({
     boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.1)',
     width: '90%',
     margin: '0 auto',
+    textAlign: 'center',
   },
   cartTable: {
     width: '100%',
+    border: '3px solid #000',
+    borderRadius: '8px',
     borderCollapse: 'collapse',
     marginTop: '20px',
+    marginLeft: 'auto',
+    marginRight: 'auto',
   },
   cartTableHeader: {
     backgroundColor: '#f4f4f4',
     fontWeight: 'bold',
     textAlign: 'left',
+    borderBottom: '3px solid #000',
+    borderTopLeftRadius: '8px',
+    borderTopRightRadius: '8px',
   },
   cartItem: {
-    borderBottom: '1px solid #ddd',
+    borderBottom: '2px solid #000',
     padding: '10px 0',
   },
   cartItemCell: {
     padding: '8px',
-    textAlign: 'left',
+    textAlign: 'center',
   },
   quantityInput: {
     padding: '5px',
@@ -45,28 +53,33 @@ const useStyles = makeStyles((theme) => ({
   },
   productDelete: {
     cursor: 'pointer',
-    width: '20px',
-    height: '20px',
+    width: '30px',
+    height: '30px'
   },
   totalPriceRow: {
     fontWeight: 'bold',
     fontSize: '18px',
     padding: '10px 0',
+    textAlign: 'left',
   },
   deleteButton: {
-    backgroundColor: '#000',
-    color: 'white',
-    padding: '10px 20px',
-    fontSize: '16px',
-    border: 'none',
-    cursor: 'pointer',
-    borderRadius: '5px',
-    marginTop: '20px',
-    display: 'block',
-    width: '200px',
-    margin: '20px auto',
-    '&:hover': {
-      backgroundColor: '#444',
+    marginTop: "20px",
+    padding: "10px 20px",
+    fontSize: "16px",
+    fontWeight: "bold",
+    color: "#fff",
+    backgroundColor: "#000",
+    border: "2px solid #000",
+    borderRadius: "8px",
+    cursor: "pointer",
+    transition: "background-color 0.3s ease, transform 0.2s ease",
+    "&:hover": {
+      backgroundColor: "#333",
+      transform: "scale(1.05)",
+    },
+    "&:active": {
+      backgroundColor: "#111",
+      transform: "scale(0.95)",
     },
   },
 }));
@@ -208,6 +221,7 @@ const CartItems = () => {
             <th className={classes.cartItemCell}>수량</th>
             <th className={classes.cartItemCell}>잔여 수량</th>
             <th className={classes.cartItemCell}>이미지</th>
+            <th className={classes.cartItemCell}>삭제</th>
           </tr>
         </thead>
         <tbody>

--- a/AutumnShop/front/Autumnshop/pages/cartItems.js
+++ b/AutumnShop/front/Autumnshop/pages/cartItems.js
@@ -1,49 +1,73 @@
 import React from "react";
 import { useEffect, useState } from "react";
 import { makeStyles } from "@mui/styles";
-import axios from "axios";
 import Payment from "./Payment";
 
 // CSS 모음
 const useStyles = makeStyles((theme) => ({
   cartContainer: {
-    width: "800px",
-    margin: "20px",
-    padding: "20px",
-    border: "1px solid #ccc",
-    borderRadius: "8px",
-    backgroundColor: "#f8f8f8",
+    padding: '20px',
+    backgroundColor: '#fff',
+    borderRadius: '8px',
+    boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.1)',
+    width: '90%',
+    margin: '0 auto',
   },
-
   cartTable: {
-    width: "800px",
+    width: '100%',
+    borderCollapse: 'collapse',
+    marginTop: '20px',
+  },
+  cartTableHeader: {
+    backgroundColor: '#f4f4f4',
+    fontWeight: 'bold',
+    textAlign: 'left',
   },
   cartItem: {
-    width: "500px",
-    border: "1px solid #ddd",
-    borderRadius: "8px",
-    backgroundColor: "#fff",
-    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.2)", // 그림자 효과를 변경
-    transition: "transform 0.3s ease-in-out", // 호버 효과를 위한 transition 추가
-    "&:hover": {
-      transform: "scale(1.05)", // 호버 시 약간 확대됨
-      boxShadow: "0 8px 16px rgba(0, 0, 0, 0.3)", // 호버 시 그림자 효과 증가
-    },
-    flexDirection: "column",
-    alignItems: "center",
-    textAlign: "center",
+    borderBottom: '1px solid #ddd',
+    padding: '10px 0',
   },
-  productImage: {
-    width: "100px",
-    alignSelf: "center",
+  cartItemCell: {
+    padding: '8px',
+    textAlign: 'left',
   },
   quantityInput: {
-    width: "50px",
+    padding: '5px',
+    fontSize: '16px',
+    borderRadius: '4px',
+    border: '1px solid #ddd',
+    width: '80px',
+  },
+  productImage: {
+    width: '50px',
+    height: '50px',
+    objectFit: 'cover',
   },
   productDelete: {
-    width: "100px",
-    alginSelf: "center",
-    cursor: "pointer",
+    cursor: 'pointer',
+    width: '20px',
+    height: '20px',
+  },
+  totalPriceRow: {
+    fontWeight: 'bold',
+    fontSize: '18px',
+    padding: '10px 0',
+  },
+  deleteButton: {
+    backgroundColor: '#000',
+    color: 'white',
+    padding: '10px 20px',
+    fontSize: '16px',
+    border: 'none',
+    cursor: 'pointer',
+    borderRadius: '5px',
+    marginTop: '20px',
+    display: 'block',
+    width: '200px',
+    margin: '20px auto',
+    '&:hover': {
+      backgroundColor: '#444',
+    },
   },
 }));
 
@@ -172,69 +196,73 @@ const CartItems = () => {
   };
 
   return (
-    <div>
-      <div className={classes.cartContainer}>
-        <h1>장바구니 목록</h1>
-        <table className={classes.cartTable}>
-          <thead>
-            <tr>
-              <th>번호</th>
-              <th>상품 이름</th>
-              <th>상품 가격</th>
-              <th>상품 설명</th>
-              <th>수량</th>
-              <th>잔여 수량</th>
-              <th>이미지</th>
-            </tr>
-          </thead>
-          <tbody className="css">
-            {cartItems.map((item, index) => (
-              <tr key={item.id} className={classes.cartItem}>
-                <td>{index + 1}</td>
-                <td>{item.productTitle}</td>
-                <td>{item.productPrice}</td>
-                <td>{item.productDescription}</td>
-                <td>
-                  <select
-                    className={classes.quantityInput}
-                    value={updatedQuantity[index] || 0}
-                    onChange={(event) => QuantityChange(event, index)}
-                  >
-                    {remainQuantity[index] && 
+    <div className={classes.cartContainer}>
+      <h1>장바구니 목록</h1>
+      <table className={classes.cartTable}>
+        <thead>
+          <tr className={classes.cartTableHeader}>
+            <th className={classes.cartItemCell}>번호</th>
+            <th className={classes.cartItemCell}>상품 이름</th>
+            <th className={classes.cartItemCell}>상품 가격</th>
+            <th className={classes.cartItemCell}>상품 설명</th>
+            <th className={classes.cartItemCell}>수량</th>
+            <th className={classes.cartItemCell}>잔여 수량</th>
+            <th className={classes.cartItemCell}>이미지</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cartItems.map((item, index) => (
+            <tr key={item.id} className={classes.cartItem}>
+              <td className={classes.cartItemCell}>{index + 1}</td>
+              <td className={classes.cartItemCell}>{item.productTitle}</td>
+              <td className={classes.cartItemCell}>{item.productPrice}</td>
+              <td className={classes.cartItemCell}>{item.productDescription}</td>
+              <td className={classes.cartItemCell}>
+                <select
+                  className={classes.quantityInput}
+                  value={updatedQuantity[index] || 0}
+                  onChange={(event) => QuantityChange(event, index)}
+                >
+                  {remainQuantity[index] &&
                     [...Array(Math.min(remainQuantity[index], 10)).keys()].map((value) => (
                       <option key={value + 1} value={value + 1}>
                         {value + 1}
                       </option>
                     ))}
-                  </select>
-                </td>
-                <td>{remainQuantity[index]}</td>
-                <td>
-                  {item.imageUrl && (
-                    <img
-                      src={item.imageUrl}
-                      alt={`Product ${index + 1}`}
-                      className={classes.productImage}
-                    />
-                  )}
-                </td>
-                <td>
+                </select>
+              </td>
+              <td className={classes.cartItemCell}>{remainQuantity[index]}</td>
+              <td className={classes.cartItemCell}>
+                {item.imageUrl && (
                   <img
+                    src={item.imageUrl}
+                    alt={`Product ${index + 1}`}
+                    className={classes.productImage}
+                  />
+                )}
+              </td>
+              <td className={classes.cartItemCell}>
+              <img
                     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAxlBMVEU9mZkAAAD////Y6+s7hYXLy8sFAAA5iora2tpDfX2+vr4/n5/c7++ntbXe8vIMHx8ICgofFxdudnZ7hYVhaWm/z89NUlIWMDD4+Pjk5OQQAADGxsZ2dnaLi4tFlZXU5uZjY2MkJCSsrKyfn587cHAtQkI5Xl4aGRm4x8fL3NyXl5dLS0svLy8kR0ciMzMXEBA8PDw6aWk7dnYxVFSJk5OSnJwsPT2bp6dCQkIjTk44VVUwYmIpPT0cKCgfICAkMDAzREQRGRkEyR6+AAAJMUlEQVR4nO2de1+iTBTHEQ2zIZ/drqCGmmSSWnnZtrRse/9v6gFdizMzEAwMzOxnfn8Cwvk699s5mv6vSyvbAO5ShPJLEcqvxISWbR+KI9u2ciS02oNevyKe+r1BOwHnd4T23bhskliN7+wshNa12Hg7ja9jUzKG0Lr7UbbxCfXjLoYxmnBQtt2pNEhNeDAp2+aUmrTTEXbKNphBnRSEtmwJuNOEWq3SCNtlm8osWk6lEF6XbWcGXSchlBmQhkgQyg1IQcQJ5S2De+FlESO0I37Wnw5nbkMcubPhtB9hqx1LSP3Vk+toyJcmjrbmOO47NTXiCCkNvbFwhGILCyFn0SJN7kQTUgrhtC4q3k6oPiWNbkcRWkQebTXE5guEGg9EPrUiCO/wJ+8d8QF9ROceN/yOTmjhz92UbXti3eCmW1TCK2kBNQ0vjFc0QjwJ78u2OpXwjGpRCLEx/YNTttGp5GDVzYBC+AieMCSoRcNCDQPY/0gSHsL/YCEXoI+4gACHBCGsZ37IlUcDOXBm8IoghBMXQ9mS0E/EISCY4ITYoEK+JPQTESLYGOERuHsjXxL6iQjb/SOMEBbDednWMmlOLYh7wufwTUPGTOpnU9BgPGOEAP+pbFsZBTs2cYQvMhZDvyC+xBDCqnQmKeEMUNiAEPZoGnwM2InLu3dqAIpDQHjAmRAhpzafDVfDoTuvabw4IeFBDGEt3w/7eOt347OiMyqb1TrAzPcrvmrlECJt/lQhZby6uc+RlEOI5m8Uvq1ai1q+jGUQIoeYQgEJOc01HUsgRHPKhC1kdHNELIEQDmjousmvi1g8ITbsjtBbbohFE6JVIsBK5SMvxIIJUZIsutNtTojFEiI4WovXew4f1IomdG5TEOY0tVcoIaIsesUpl+nZQgnhx/5qM5lEpewm+yeLJUTk+vPF73Ov2/XOj0/P+hTEdQ6JyJcQjoiIJHwemaZZ9WWazWbXWxr4A3msk3AldNz1rOHsORHeG102t3h7+ZRLHDGHiQWOhM50lyb96WJed/zxILb39leziqs5workT5EJ62Bp6/ZyivVmTklAH/EcS8TspZ8f4aYSq0cKX4B4DB/LvlbCixCt4wErx36xM00K4gl47E1YQmKFGdft+Gw5Oq8SmKYHHsu+oseLEF9gjtDk+eT3qNsMczZ74QeMzAWRF2H9u3F8WLe95bHntxbb1tH8De5lXg/ilobfVDQUjU9+jTw/PWF1mnlCg1tNk7KTvdfk4vQXaDczt/ncahpqL5tBmZsLboQpRvOxmmWdBufX4qMh0ZFm0WY6bAR9PmZOjv1SVFukr26oMjaXK7ehsUFyHVsgzWnMVnmdtTEW4hFuKX0589nNW6opGro2LB2cgsb4AWbNXbz2syG+iUv4ieln20WGbMvQOhY/q7/Ltus/HyyHURmGGmWtkO6y7epyk6b/Wqk81GUh/OR06o3hdJIYsyUZ4U5BY153109JMBkm3wQg3GqbbRvu6u0jFvRemnIYoW3p9LPtexTmXHbCnYLzWTX3hZJtWTaAiki4VVA6ncZ6tfnac1N5ZXmRsIQ7bbPtfPj69tB6uGfIoloRhCgXOXXW84D8e97u03856NVlHSFyJkS1ZLOKCdRi3CvFmbCRyzj/r9iWhDkT5paCgdh2Z/Ad48P9uZnFNLPIl5B6rJpdT+IR5uyP6CcDoCJUhIpQESpCuQgnZwwCR61FJzxpMuhULkL6Fpo4KUJFqAh5Epq0LV+766Eb8hI2u+ej8y5l+6U3Oh55X/tOZSU0u6d9/8Jk2cX2tHVPtpMCZ54pN6F53v97aeKFEU1vvxJujEypCbtfszeTcBJ2Q1s3/qLLSQh2kC6/yiKgOWtKTFgNXwxtFe6C9f2uvITmCLz2fF8STbgn8diUlxDu5FaEilARKkJFqAgVoSJUhIpQESpCRagIFaEiVISKUBEqQkWoCBWhIlSEilARKkJFqAgVoSJUhIpQESpCRSg2YdS+NugSciQvYdUMX3z82kJrgvBSMu++BFaHXO0Cl5BLmQmr3f7ntWewC/riK2mrlH9DHkLT25/XGmNb2Xv4deEJgY+2s9Be/WXA+Pyrip25MI8vjMCN+ef15ln4DX3xCPvhFzyHUJpVz/Oq5HkL0/Svh46UNMEbJuIR/gFvAEcP8OSjCmtBpuKdx4cOodMffMIcQzO52efrFwNGBPtq3RMK6xywBUbj7PkDWnjrpUI0vT74eUs8zx8awkKP/Rg1EzOazRF2UPpVQO8tyK1gOtt6706g7ugE/y2bW2jOuZQSWGYyvkigMekgk9E9O28vSjn5Sw7E6BWatyesdNGB4vTA9H3+hKkiPMWKzVtbEd7M8NgrjPrD6u66AJ97ubi8ZvEgXBhhHkUxQxC2AghRLTPiQ53d9XwRniERQygIoI8sYTsL8n2ZLKxjhKZZvlyYx/IGczJ+sDYTxRJqSJsxMT7MsgaWLc5DK9Iaf1L6iTRu5owBEUohDCBRzV3d3F8m0P3Nyq1lx9Pi43LziK2exu9sLh+Mja1ug3s5hLErQ5j/TRsQWuDei6SEL4DCAoQ6uMfkaloAvQIKHRICZ2mtsk1lFPB7/ogRdjhUNUULVjRXGOE1uJtPeN6ChcUOu8YIYWVqlG0tk2Anw8YIdTjskbC9wNqKjY4TwoL4Uba9DPoABB2CEPbbcggKWrDwycwDgtCC87JG+igv5aoOS+HEIgj1K/gfZI97WqjQGzT/SicJYW3KuEZZlogokzaFUO9hD0lUFIkVhZ5OI8QTUR5EcsnEphJiDYY8GZUMhNrR6YQW/mDlPcPkZVFCdTJogRVBiHVOA7WGuUwv8BPS1mQkpWs9ilC/IB6ufDBHfSlACLmUab0LPZqQzKdBOi5qmoCUvkm1BTXglxVDiPfd9vo5HTZqdZEUBDT7STf2QI8j1Af0X21liKMYKwd6PCHeeZNOVzgQQSg5IgFIIZQakQSkEcaWRbGFl8EowqgaVXi1aTBUQt2iNP3Ca2xRWeiEtA6c6KLl0DhC3cKHi2KrZ0eBRBL640V5GHuH0RgxhD5jJ7etahx124lMv28J/bx6RAyLBVPniF7BJCUMdDjoiZmUt71BTO5MQbiVfdBuH4mjdvsgNmsyEMorRSi/FKH8+vcJ/wfHnmmQIvHBowAAAABJRU5ErkJggg=="
                     className={classes.productDelete}
                     onClick={() => deleteCartItem(cartMemberId, item.id)}
                   />
-                </td>
-              </tr>
-            ))}
-            <tr>
-              <td>총 가격 : {totalPrice}</td>
+              </td>
             </tr>
-          </tbody>
-        </table>
+          ))}
+        </tbody>
+      </table>
+
+      <div className={classes.totalPriceRow}>
+        <span>총액: {totalPrice}</span>
       </div>
-      <Payment cartId={cartMemberId} quantity={updatedQuantity} totalPrice={totalPrice}/>
-      <button onClick={() => allDeleteCartItem(cartMemberId)}>삭제</button>
+
+      <div className={classes.paymentContainer}>
+        <Payment cartId={cartMemberId} quantity={updatedQuantity} totalPrice={totalPrice} />
+      </div>
+      <button onClick={() => allDeleteCartItem(cartMemberId)} className={classes.deleteButton}>
+        장바구니 전체 삭제
+      </button>
     </div>
   );
 };

--- a/AutumnShop/front/Autumnshop/pages/order.js
+++ b/AutumnShop/front/Autumnshop/pages/order.js
@@ -1,168 +1,166 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { makeStyles } from "@mui/styles";
-import { useState, useEffect } from "react";
 
-const useStyles = makeStyles((theme) => ({
-    cartContainer: {
-      width: "100%",
-      maxWidth: "800px",
-      margin: "20px auto",
-      padding: "20px",
-      border: "1px solid #ccc",
-      borderRadius: "8px",
-      backgroundColor: "#f8f8f8",
-    },
-    cartTable: {
-      width: "800px",
-    },
-    cartItem: {
-      width: "500px",
-      border: "1px solid #ddd",
-      borderRadius: "8px",
-      backgroundColor: "#fff",
-      boxShadow: "0 4px 8px rgba(0, 0, 0, 0.2)", 
-      transition: "transform 0.3s ease-in-out", 
-      "&:hover": {
-        transform: "scale(1.05)", 
-        boxShadow: "0 8px 16px rgba(0, 0, 0, 0.3)", 
-      },
-      flexDirection: "column",
-      alignItems: "center",
-      textAlign: "center",
-    },
-      productImage: {
-      width: "100px",
-      alignSelf: "center",
-    },
-      
-    headerRow: {
-        display: "flex",
-        justifyContent: "space-between",
-        padding: "10px",
-        margin: "0 0 10px 0",
-        border: "1px solid #007bff",
-        borderRadius: "12px",
-        backgroundColor: "#007bff",
-        color: "white",
-        fontWeight: "bold",
+// 스타일 정의
+const useStyles = makeStyles(() => ({
+  cartContainer: {
+    width: "100%",
+    maxWidth: "900px",
+    margin: "20px auto",
+    padding: "20px",
+    border: "3px solid #000",
+    borderRadius: "8px",
+    backgroundColor: "#fff",
+    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+    textAlign: "center",
   },
-    detailRow: {
-        flexDirection: "column", 
-        padding: "8px",
-        margin: "5px 0",
-        border: "1px solid #eee",
-        borderRadius: "8px",
-        backgroundColor: "#fafafa",
-        boxShadow: "0 2px 4px rgba(0, 0, 0, 0.05)",
-    },
-    productDetailContainer: {
-        display: "flex",
-        justifyContent: "space-between",  
-        alignItems: "center",
-        marginBottom: "5px",
-    },
-    productCell: {
-        padding: "5px 10px",
-        flex: 1, 
+  heading: {
+    fontSize: "32px",
+    fontWeight: "bold",
+    color: "#333",
+    marginBottom: "20px",
+  },
+  cartTable: {
+    width: "100%",
+    borderCollapse: "collapse",
+  },
+  headerRow: {
+    display: "table-row",
+    backgroundColor: "#000",
+    color: "white",
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  headerCell: {
+    padding: "12px 20px",
+    border: "1px solid #ddd",
+    textAlign: "center",
+  },
+  detailRow: {
+    display: "table-row",
+    backgroundColor: "#fff",
+    borderBottom: "1px solid #ddd",
+    marginBottom: "15px",
+  },
+  detailCell: {
+    padding: "15px 20px",
+    border: "1px solid #ddd",
+    textAlign: "center",
+    fontSize: "18px",
+  },
+  productImage: {
+    width: "100px",
+    marginTop: "10px",
+    marginLeft: "auto",
+    marginRight: "auto",
+  },
+}));
+
+// OrderDetails 컴포넌트
+function OrderDetails() {
+  const classes = useStyles();
+  const [loading, setLoading] = useState(true);
+  const [orderid, setOrderid] = useState([]);
+  const [payment, setPayment] = useState([]);
+
+  // 주문 세부 정보 가져오기
+  useEffect(() => {
+    const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+
+    async function fetchOrderDetails() {
+      const orderresponse = await fetch(`http://localhost:8080/orders`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${loginInfo.accessToken}`,
+        },
+      });
+
+      if (!orderresponse.ok) {
+        throw new Error('주문 정보를 불러오는 데 실패했습니다.');
+      }
+
+      const orderDetails = await orderresponse.json();
+      setLoading(false);
+      setOrderid(orderDetails.map(order => order.id));
     }
-  }));
 
-function OrderDetails({}){
-    const classes = useStyles();
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(' ');
-    const [orderid, setOrderid] = useState([]);
-    const [payment, setPayment] = useState([])
+    fetchOrderDetails();
+  }, []);
 
-    useEffect(() => {
-        const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
-        
-        async function fetchOrderDetails() {
-            const orderresponse = await fetch(`http://localhost:8080/orders`,{
-              method: "GET",
-                headers : {
-                    Authorization: `Bearer ${loginInfo.accessToken}`,
-                },
-            });
-
-            if (!orderresponse.ok) {
-              throw new Error('주문 정보를 불러오는 데 실패했습니다.');
-            }
-    
-            const orderDetails = await orderresponse.json();
-            setLoading(false);
-            setOrderid(orderDetails.map(order => order.id));
-        }
-
-        fetchOrderDetails();
-    }, []);
-
-    useEffect(() => {
-      async function fetchOrderFollow() {
-        try {
-          const paymentPromises = orderid.map(async (orderid) => {
-            const response = await fetch(`http://localhost:8080/payment/order?orderId=${orderid}`, {
-              method: "GET",
-              headers: {
-                Authorization: `Bearer ${JSON.parse(localStorage.getItem("loginInfo")).accessToken}`,
-              },
-            });
-    
-            if (!response.ok) {
-              throw new Error(`주문 ID의 정보를 불러오는 데 실패했습니다.: ${orderid}`);
-            }
-    
-            return response.json(); 
+  // 주문에 대한 결제 정보 가져오기
+  useEffect(() => {
+    async function fetchOrderFollow() {
+      try {
+        const paymentPromises = orderid.map(async (orderid) => {
+          const response = await fetch(`http://localhost:8080/payment/order?orderId=${orderid}`, {
+            method: "GET",
+            headers: {
+              Authorization: `Bearer ${JSON.parse(localStorage.getItem("loginInfo")).accessToken}`,
+            },
           });
-    
-          const payments = await Promise.all(paymentPromises);
-          setPayment(payments);
-        } catch (error) {
-          console.error('구매 정보를 불러오는 데 실패했습니다.:', error);
-        }
-      }
-    
-      if (orderid.length > 0) {
-        fetchOrderFollow();
-      }
-    }, [orderid]);
 
-    if(loading) return <div>Loading...</div>;
+          if (!response.ok) {
+            throw new Error(`주문 ID의 정보를 불러오는 데 실패했습니다.: ${orderid}`);
+          }
 
-    return (
-        <div className={classes.cartContainer}>
-        <div className={classes.headerRow}>
-          <div>주문번호</div>
-          <div>물품</div>
-          <div>가격</div>
-          <div>평점</div>
-          <div>수량</div>
-          <div>주문날짜</div>
-          <div>이미지</div>
-        </div>
-        {payment && payment.map((paymentitem, index) => (
-          <div key={index} className={classes.detailRow}>
-            {paymentitem.map((item, idx) => (
-              <div key={idx} className={classes.productDetailContainer}>
-                <span className={classes.productCell}>{index + 1}</span>
-                <span className={classes.productCell}>{item.productTitle}</span>
-                <span className={classes.productCell}>{item.productPrice}</span>
-                <span className={classes.productCell}>{item.productRate}</span>
-                <span className={classes.productCell}>{item.quantity}</span>
-                <span className={classes.productCell}>{item.date}</span>
-                {item.imageUrl && (
-                  <img
-                    src={item.imageUrl}
-                    alt={`Product ${idx + 1}`}
-                    className={classes.productImage}
-                  />
-                )}
-              </div>
-            ))}
-          </div>
-        ))}
-        </div>
-      );
+          return response.json();
+        });
+
+        const payments = await Promise.all(paymentPromises);
+        setPayment(payments);
+      } catch (error) {
+        console.error('구매 정보를 불러오는 데 실패했습니다.:', error);
+      }
     }
+
+    if (orderid.length > 0) {
+      fetchOrderFollow();
+    }
+  }, [orderid]);
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className={classes.cartContainer}>
+      {payment && payment.map((paymentitem, index) => (
+        <div key={index}>
+          <h2>주문번호 : {orderid[index]}</h2>
+          <table className={classes.cartTable}>
+            <thead>
+              <tr className={classes.headerRow}>
+                <th className={classes.headerCell}>물품</th>
+                <th className={classes.headerCell}>가격</th>
+                <th className={classes.headerCell}>평점</th>
+                <th className={classes.headerCell}>수량</th>
+                <th className={classes.headerCell}>주문날짜</th>
+                <th className={classes.headerCell}>이미지</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paymentitem.map((item, idx) => (
+                <tr key={idx} className={classes.detailRow}>
+                  <td className={classes.detailCell}>{item.productTitle}</td>
+                  <td className={classes.detailCell}>{item.productPrice}</td>
+                  <td className={classes.detailCell}>{item.productRate}</td>
+                  <td className={classes.detailCell}>{item.quantity}</td>
+                  <td className={classes.detailCell}>{item.date}</td>
+                  <td className={classes.detailCell}>
+                    {item.imageUrl && (
+                      <img
+                        src={item.imageUrl}
+                        alt={`Product ${idx + 1}`}
+                        className={classes.productImage}
+                      />
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default OrderDetails;

--- a/AutumnShop/front/Autumnshop/pages/paymentList/[param].js
+++ b/AutumnShop/front/Autumnshop/pages/paymentList/[param].js
@@ -1,41 +1,83 @@
-import React from "react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { makeStyles } from "@mui/styles";
 import PaymentDate from "./paymentDate";
-import { Button, Box } from "@mui/material";
 
-// CSS 모음
-const useStyles = makeStyles((theme) => ({
-  cartContainer: {
-    width: "800px",
-    margin: "20px",
+// CSS 적용
+const useStyles = makeStyles(() => ({
+  tableContainer: {
+    width: "60%",
+    margin: "20px auto",
     padding: "20px",
-    border: "1px solid #ccc",
-    borderRadius: "8px",
-    backgroundColor: "#f8f8f8",
-  },
-
-  cartTable: {
-    width: "800px",
-  },
-  cartItem: {
-    width: "500px",
-    border: "1px solid #ddd",
+    border: "3px solid #000",
     borderRadius: "8px",
     backgroundColor: "#fff",
-    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.2)", // 그림자 효과를 변경
-    transition: "transform 0.3s ease-in-out", // 호버 효과를 위한 transition 추가
-    "&:hover": {
-      transform: "scale(1.05)", // 호버 시 약간 확대됨
-      boxShadow: "0 8px 16px rgba(0, 0, 0, 0.3)", // 호버 시 그림자 효과 증가
-    },
-    flexDirection: "column",
-    alignItems: "center",
+    color: "#000",
+    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
     textAlign: "center",
   },
-  productImage: {
-    width: "100px",
-    alignSelf: "center",
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+    fontSize: "14px",
+  },
+  tableHeader: {
+    backgroundColor: "#f4f4f4",
+    color: "#000",
+    textAlign: "center",
+    fontWeight: "bold",
+    borderBottom: "3px solid #000",
+    padding: "10px",
+  },
+  tableCell: {
+    padding: "10px",
+    borderBottom: "2px solid #000",
+    textAlign: "center",
+    fontSize: "20px",
+  },
+  tableRow: {
+    "&:hover": {
+      backgroundColor: "#f1f1f1",
+    },
+  },
+  totalContainer: {
+    marginTop: "20px",
+    padding: "10px",
+    backgroundColor: "#f4f4f4",
+    borderRadius: "8px",
+    fontSize: "18px",
+    fontWeight: "bold",
+    textAlign: "center",
+    color: "#000",
+    border: "2px solid #000",
+  },
+  paginationContainer: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: "20px",
+    gap: "10px",
+  },
+  paginationButton: {
+    padding: "8px 15px",
+    border: "2px solid #000",
+    borderRadius: "4px",
+    backgroundColor: "#fff",
+    cursor: "pointer",
+    color: "#000",
+    fontWeight: "bold",
+    fontSize: "14px",
+    "&:disabled": {
+      backgroundColor: "#e0e0e0",
+      cursor: "not-allowed",
+    },
+    "&:hover": {
+      backgroundColor: "#f1f1f1",
+    },
+  },
+  currentPage: {
+    fontWeight: "bold",
+    color: "#000",
+    fontSize: "16px",
   },
 }));
 
@@ -51,7 +93,7 @@ async function getCartItem(loginInfo, setPaymentItems, page, year, month) {
         headers: {
             Authorization: `Bearer ${loginInfo.accessToken}`,
           },
-        })
+        });
         const data = await paymentResponse.json();
         setPaymentItems(data);
     } catch (error) {
@@ -59,14 +101,14 @@ async function getCartItem(loginInfo, setPaymentItems, page, year, month) {
     }
   } else {
     try{
-    const paymentPage = page || 0;
-    // 1. 현재 로그인한 아이디에 따라 맞는 카트 가져옴
-    const paymentResponse = await fetch(`http://localhost:8080/payment?page=${paymentPage}`, {
-      method: "GET",  
-      headers: {
-          Authorization: `Bearer ${loginInfo.accessToken}`,
-        },
-      });
+      const paymentPage = page || 0;
+      // 현재 로그인한 아이디에 따라 맞는 카트 가져옴
+      const paymentResponse = await fetch(`http://localhost:8080/payment?page=${paymentPage}`, {
+        method: "GET",  
+        headers: {
+            Authorization: `Bearer ${loginInfo.accessToken}`,
+          },
+        });
       const data = await paymentResponse.json();
       setPaymentItems(data);
     } catch (error){
@@ -107,111 +149,94 @@ const paymentList = () => {
   const totalPages = paymentItems.totalPages;
 
   return (
-    <div>
+    <div className={classes.tableContainer}>
       <PaymentDate classes={classes} />
-      <div className={classes.cartContainer}>
-        <h1>구매 목록</h1>
-        <table className={classes.cartTable}>
-          <thead>
-            <tr>
-              <th>번호</th>
-              <th>상품 이름</th>
-              <th>상품 가격</th>
-              <th>평점</th>
-              <th>수량</th>
-              <th>이미지</th>
-              <th>날짜</th>
-            </tr>
-          </thead>
-          <tbody className="css">
-            {paymentItems.content &&
-              paymentItems.content.map((item, index) => (
-                <tr key={item.id} className={classes.cartItem}>
-                  <td>{index + 1}</td>
-                  <td>{item.productTitle}</td>
-                  <td>{item.productPrice}</td>
-                  <td>{item.productRate}</td>
-                  <td>{item.quantity}</td>
-                  <td>
-                    {item.imageUrl && (
-                      <img
-                        src={item.imageUrl}
-                        alt={`Product ${index + 1}`}
-                        className={classes.productImage}
-                      />
-                    )}
-                  </td>
-                  <td>{item.date}</td>
-                </tr>
-              ))}
-            <tr>
-              <td>총 가격 : {totalPrice}</td>
-            </tr>
-          </tbody>
-        </table>
+      <h1>구매 목록</h1>
+      <table className={classes.table}>
+        <thead>
+          <tr className={classes.tableHeader}>
+            <th className={classes.tableCell}>번호</th>
+            <th className={classes.tableCell}>상품 이름</th>
+            <th className={classes.tableCell}>상품 가격</th>
+            <th className={classes.tableCell}>평점</th>
+            <th className={classes.tableCell}>수량</th>
+            <th className={classes.tableCell}>이미지</th>
+            <th className={classes.tableCell}>날짜</th>
+          </tr>
+        </thead>
+        <tbody>
+          {paymentItems.content &&
+            paymentItems.content.map((item, index) => (
+              <tr key={item.id} className={classes.tableRow}>
+                <td className={classes.tableCell}>{index + 1}</td>
+                <td className={classes.tableCell}>{item.productTitle}</td>
+                <td className={classes.tableCell}>{item.productPrice}</td>
+                <td className={classes.tableCell}>{item.productRate}</td>
+                <td className={classes.tableCell}>{item.quantity}</td>
+                <td className={classes.tableCell}>
+                  {item.imageUrl && (
+                    <img
+                      src={item.imageUrl}
+                      alt={`Product ${index + 1}`}
+                      style={{ width: "100px", alignSelf: "center" }}
+                    />
+                  )}
+                </td>
+                <td className={classes.tableCell}>{item.date}</td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+
+      <div className={classes.totalContainer}>
+        총 가격 : {totalPrice}
       </div>
-      <Box display="flex" justifyContent="center" marginBottom={3}>
-        {/* 페이지 네비게이터 버튼 */}
-        <a
-          href={
-            dateParams.year && dateParams.month
-              ? `/paymentList?year=${dateParams.year}&month=${dateParams.month}&pageNumber=0`
-              : `/paymentList?pageNumber=0`
+
+      <div className={classes.paginationContainer}>
+        <button
+          className={classes.paginationButton}
+          onClick={() =>
+            window.location.href = `${dateParams.year && dateParams.month ? `/paymentList?year=${dateParams.year}&month=${dateParams.month}&pageNumber=0` : `/paymentList?pageNumber=0`}`
           }
         >
-          <Button variant="outlined">첫페이지</Button>
-        </a>
-        <a
-          href={
-            dateParams.year && dateParams.month
-              ? `/paymentList?year=${dateParams.year}&month=${
-                  dateParams.month
-                }&pageNumber=${Math.max(0, pageNumber - 1)}`
-              : `/paymentList?pageNumber=${Math.max(0, pageNumber - 1)}`
+          첫페이지
+        </button>
+        <button
+          className={classes.paginationButton}
+          onClick={() =>
+            window.location.href = `${dateParams.year && dateParams.month ? `/paymentList?year=${dateParams.year}&month=${dateParams.month}&pageNumber=${Math.max(0, pageNumber - 1)}` : `/paymentList?pageNumber=${Math.max(0, pageNumber - 1)}`}`
           }
         >
-          <Button variant="outlined">이전</Button>
-        </a>
+          이전
+        </button>
         {Array.from({ length: totalPages }, (_, i) => (
-          <a
-            href={
-              dateParams.year && dateParams.month
-                ? `/paymentList?year=${dateParams.year}&month=${dateParams.month}&pageNumber=${i}`
-                : `/paymentList?pageNumber=${i}`
-            }
+          <button
             key={i}
+            className={classes.paginationButton}
+            onClick={() =>
+              window.location.href = `${dateParams.year && dateParams.month ? `/paymentList?year=${dateParams.year}&month=${dateParams.month}&pageNumber=${i}` : `/paymentList?pageNumber=${i}`}`
+            }
           >
-            <Button variant="outlined" selected={i === pageNumber}>
-              {i + 1}
-            </Button>
-          </a>
+            {i + 1}
+          </button>
         ))}
-        <a
-          href={
-            dateParams.year && dateParams.month
-              ? `/paymentList?year=${dateParams.year}&month=${
-                  dateParams.month
-                }&pageNumber=${Math.min(totalPages - 1, pageNumber + 1)}`
-              : `/paymentList?pageNumber=${Math.min(
-                  totalPages - 1,
-                  pageNumber + 1
-                )}`
+        <button
+          className={classes.paginationButton}
+          onClick={() =>
+            window.location.href = `${dateParams.year && dateParams.month ? `/paymentList?year=${dateParams.year}&month=${dateParams.month}&pageNumber=${Math.min(totalPages - 1, pageNumber + 1)}` : `/paymentList?pageNumber=${Math.min(totalPages - 1, pageNumber + 1)}`}`
           }
         >
-          <Button variant="outlined">다음</Button>
-        </a>
-        <a
-          href={
-            dateParams.year && dateParams.month
-              ? `/paymentList?year=${dateParams.year}&month=${
-                  dateParams.month
-                }&pageNumber=${totalPages - 1}`
-              : `/paymentList?pageNumber=${totalPages - 1}`
+          다음
+        </button>
+        <button
+          className={classes.paginationButton}
+          onClick={() =>
+            window.location.href = `${dateParams.year && dateParams.month ? `/paymentList?year=${dateParams.year}&month=${dateParams.month}&pageNumber=${totalPages - 1}` : `/paymentList?pageNumber=${totalPages - 1}`}`
           }
         >
-          <Button variant="outlined">마지막페이지</Button>
-        </a>
-      </Box>
+          마지막페이지
+        </button>
+      </div>
     </div>
   );
 };

--- a/AutumnShop/front/Autumnshop/pages/paymentList/paymentDate.js
+++ b/AutumnShop/front/Autumnshop/pages/paymentList/paymentDate.js
@@ -1,7 +1,75 @@
-import React from "react";
-import { useEffect, useState } from "react";
+import React, { useState } from "react";
+import { makeStyles } from "@material-ui/core/styles";
 
-const paymentDate = (classes) => {
+const useStyles = makeStyles(() => ({
+  tableContainer: {
+    width: "80%",
+    margin: "0 auto",
+    padding: "20px",
+    border: "3px solid #000",
+    borderRadius: "10px",
+    backgroundColor: "#f0f0f0",
+    textAlign: "center",
+    boxShadow: "0px 0px 10px rgba(0, 0, 0, 0.1)",
+  },
+
+  heading: {
+    fontSize: "24px",
+    marginBottom: "20px",
+    color: "#333",
+  },
+
+  dateContainer: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: "30px",
+    backgroundColor: "#f0f0f0",
+    padding: "20px",
+    borderRadius: "10px",
+  },
+
+  dateInput: {
+    padding: "15px 25px",
+    fontSize: "24px",
+    border: "2px solid #ccc",
+    borderRadius: "10px",
+    width: "150px",
+    backgroundColor: "#fff",
+    color: "#333",
+    cursor: "pointer",
+    "&:hover": {
+      borderColor: "#000",
+    },
+    "&:focus": {
+      outline: "none",
+      borderColor: "#000",
+    },
+  },
+
+  textStyle: {
+    fontSize: "24px",
+    fontWeight: "bold",
+    color: "#333",
+  },
+
+  searchButton: {
+    padding: "15px 35px",
+    border: "2px solid #000",
+    borderRadius: "10px",
+    backgroundColor: "#000",
+    cursor: "pointer",
+    fontWeight: "bold",
+    fontSize: "20px",
+    color: "#fff",
+    "&:hover": {
+      backgroundColor: "#333",
+    },
+  },
+}));
+
+const paymentDate = () => {
+  const classes = useStyles();
   const [selectedYear, setSelectedYear] = useState(2025);
   const [selectedMonth, setSelectedMonth] = useState(1);
 
@@ -14,33 +82,39 @@ const paymentDate = (classes) => {
   };
 
   return (
-    <div className={classes.cartContainer}>
-      <select
-        className={classes.dateInput}
-        value={selectedYear}
-        name="paymentYear"
-        onChange={(event) => handleChange(event, setSelectedYear)}
-      >
-        {[2025, 2024, 2023, 2022, 2021, 2020].map((value) => (
-          <option key={value} value={value}>
-            {value}
-          </option>
-        ))}
-      </select>
-      년
-      <select
-        className={classes.dateInput}
-        value={selectedMonth}
-        name="paymentMonth"
-        onChange={(event) => handleChange(event, setSelectedMonth)}
-      >
-        {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((value) => (
-          <option key={value} value={value}>
-            {value}
-          </option>
-        ))}
-      </select>
-      월<button onClick={dateSearch}>검색</button>
+    <div className={classes.tableContainer}>
+      <h1 className={classes.heading}>결제 검색</h1>
+      <div className={classes.dateContainer}>
+        <select
+          className={classes.dateInput}
+          value={selectedYear}
+          name="paymentYear"
+          onChange={(event) => handleChange(event, setSelectedYear)}
+        >
+          {[2025, 2024, 2023, 2022, 2021, 2020].map((value) => (
+            <option key={value} value={value}>
+              {value}
+            </option>
+          ))}
+        </select>
+        <span className={classes.textStyle}>년</span>
+        <select
+          className={classes.dateInput}
+          value={selectedMonth}
+          name="paymentMonth"
+          onChange={(event) => handleChange(event, setSelectedMonth)}
+        >
+          {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((value) => (
+            <option key={value} value={value}>
+              {value}
+            </option>
+          ))}
+        </select>
+        <span className={classes.textStyle}>월</span>
+        <button onClick={dateSearch} className={classes.searchButton}>
+          검색
+        </button>
+      </div>
     </div>
   );
 };

--- a/AutumnShop/front/Autumnshop/pages/paymentList/paymentDate.js
+++ b/AutumnShop/front/Autumnshop/pages/paymentList/paymentDate.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { makeStyles } from "@material-ui/core/styles";
+import { makeStyles } from "@mui/styles";
 
 const useStyles = makeStyles(() => ({
   tableContainer: {

--- a/AutumnShop/front/Autumnshop/pages/paymentMileage.js
+++ b/AutumnShop/front/Autumnshop/pages/paymentMileage.js
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 const useStyles = makeStyles(() => ({
   container: {
     padding: "20px",
-    border: "1px solid #ccc",
+    border: "2px solid #333",
     borderRadius: "8px",
     backgroundColor: "#f8f8f8",
     textAlign: "center",
@@ -15,8 +15,8 @@ const useStyles = makeStyles(() => ({
     padding: "10px",
     margin: "10px 0",
     borderRadius: "8px",
-    border: "1px solid #ddd",
-    width: "80%",
+    border: "2px solid #666",
+    width: "60%",
     fontSize: "16px",
   },
   button: {
@@ -24,17 +24,17 @@ const useStyles = makeStyles(() => ({
     fontSize: "16px",
     fontWeight: "bold",
     color: "#fff",
-    backgroundColor: "#007BFF",
-    border: "none",
+    backgroundColor: "#000",
+    border: "2px solid #000",
     borderRadius: "8px",
     cursor: "pointer",
     transition: "background-color 0.3s ease, transform 0.2s ease",
     "&:hover": {
-      backgroundColor: "#0056b3",
+      backgroundColor: "#333",
       transform: "scale(1.05)",
     },
     "&:active": {
-      backgroundColor: "#003f7f",
+      backgroundColor: "#111",
       transform: "scale(0.95)",
     },
   },
@@ -117,7 +117,7 @@ const paymentMileage = ({ totalPrice, onMileageApply, remainPrice, setRemainPric
     <div className={classes.container}>
       <h3 className={classes.title}>마일리지 사용</h3>
       <p className={classes.totalPrice}>총 금액: {totalPrice.toLocaleString()}원</p>
-      <p className={classes.currentMileage}>현재 마일리지: {userMileage.toLocaleString()}원</p>
+      <p className={classes.currentMileage}>현재 보유 마일리지: {userMileage.toLocaleString()}원</p>
       <input
         type="number"
         placeholder="사용할 마일리지 입력"
@@ -126,10 +126,10 @@ const paymentMileage = ({ totalPrice, onMileageApply, remainPrice, setRemainPric
         className={classes.input}
       />
       <button onClick={applyMileage} className={classes.button}>
-        사용
+        마일리지 사용
       </button>
       <p className={classes.remainingPrice}>적용 후 금액: {remainPrice.toLocaleString()}원</p>
-      <p className={classes.remainingPrice}>적용 후 마일리지: {remainingMileage.toLocaleString()}원</p>
+      <p className={classes.remainingPrice}>남은 마일리지: {remainingMileage.toLocaleString()}원</p>
     </div>
   );
 };


### PR DESCRIPTION
close #60 

1. 카트 목록 = 장바구니 목록 디자인 적용 및 불필요한 axios단 제거,  paymentSubmit 리팩토링
2. 주문정보, 구매 목록 css 내 정보 페이지의 디자인 혹은 마일리지 내역과 동일하게 적용함
3. 구매목록의 날짜 표시 css 좀더 세련되게 적용함
4. carItems css 수정 및 이미지에 맞게 삭제 속성 추가, paymentDate import 잘못되던 점 수정