### PR TITLE
메인 페이지 및 AppBar css 변경 완료

### DIFF
--- a/AutumnShop/front/Autumnshop/components/DesktopAppBar.js
+++ b/AutumnShop/front/Autumnshop/components/DesktopAppBar.js
@@ -1,38 +1,79 @@
-import { AppBar, Toolbar, Typography, Button } from "@mui/material";
+import { AppBar, Toolbar, Typography, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
 import Link from "next/link";
 import React, { useState, useEffect } from "react";
-import axios from "axios";
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-} from "@mui/material";
-import useLogout from "../hooks/useLogout"; // Import useAuth
+import useLogout from "../hooks/useLogout";
+import { makeStyles } from "@mui/styles";
+
+const useStyles = makeStyles((theme) => ({
+  appBar: {
+    backgroundColor: "#000",
+    color: "#fff",
+  },
+  toolbar: {
+    display: "flex",
+    justifyContent: "flex-start",
+    alignItems: "center",
+    width: "100%",
+    position: "relative",
+    paddingTop: "8px",
+  },
+  logo: {
+    textDecoration: "none",
+    color: "#fff",
+    fontSize: "32px",
+    fontWeight: "bold",
+    transition: "transform 0.3s ease",
+    position: "absolute",
+    left: "50%",
+    transform: "translateX(-50%)",
+    top: "10px",
+    "&:hover": {
+      transform: "scale(1.2) translateX(-50%)",
+    },
+  },
+  buttonContainer: {
+    display: "flex",
+    marginLeft: "auto",
+    marginRight: "40px",
+    marginBottom: "10px",
+  },
+  button: {
+    fontSize: "18px",
+    border: "2px solid #fff",
+    borderRadius: "4px",
+    padding: "6px 16px",
+    color: "#fff",
+    marginLeft: "16px",
+    "&:hover": {
+      border: "2px solid #fff",
+      backgroundColor: "rgba(255, 255, 255, 0.1)",
+    },
+  },
+  link: {
+    textDecoration: "none",
+    color: "inherit",
+  },
+}));
 
 const DesktopAppBar = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태 추가
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const {
     logoutDialogOpen,
     handleLogoutDialogOpen,
     handleLogoutDialogClose,
     handleLogout,
-  } = useLogout(); // 커스텀 훅 사용
+  } = useLogout();
+
+  const classes = useStyles();
 
   useEffect(() => {
     const handleLoginStatusChange = () => {
       const loginInfo = localStorage.getItem("loginInfo");
-      if (loginInfo) {
-        setIsLoggedIn(true);
-      } else {
-        setIsLoggedIn(false);
-      }
+      setIsLoggedIn(!!loginInfo);
     };
 
     // 컴포넌트 마운트 시 초기 로그인 상태 확인
     handleLoginStatusChange();
-
     window.addEventListener("loginStatusChanged", handleLoginStatusChange);
 
     return () => {
@@ -41,68 +82,43 @@ const DesktopAppBar = () => {
   }, []);
 
   return (
-    <AppBar position="static">
-      <Toolbar>
-        <Link href="/" passHref>
-          <Typography
-            variant="h6"
-            style={{ textDecoration: "none", color: "inherit" }}
-          >
-            <img src="https://via.placeholder.com/30" alt="logo" width="30" />{" "}
-            Meet42
-          </Typography>
-        </Link>
-        <div style={{ flexGrow: 1 }} />
-        <Link href="/order" passHref>
-        <Button
-          color="inherit"
-          style={{ display: isLoggedIn ? "block" : "none"}}
-        >
-          주문내역
-        </Button>
-        </Link>
+    <AppBar position="static" className={classes.appBar}>
+      <Toolbar className={classes.toolbar}>
+        <div className={classes.logoContainer}>
+          <Link href="/" passHref className={classes.link}>
+            <Typography variant="h6" className={classes.logo}>
+              AutumnsMall
+            </Typography>
+          </Link>
+        </div>
 
-        <Link href="/products" passHref>
-          <Button color="inherit">상품목록</Button>
-        </Link>
-        <Link href="/cartItems" passHref>
-          <Button
-            color="inherit"
-            style={{ display: isLoggedIn ? "block" : "none" }}
-          >
-            카트목록
-          </Button>
-        </Link>
-        <Link href="/paymentList" passHref>          <Button
-            color="inherit"
-            style={{ display: isLoggedIn ? "block" : "none" }}
-          >
-            구매목록
-          </Button>
-        </Link>
-        <Link href="/mypage" passHref>
-          <Button
-            color="inherit"
-            style={{ display: isLoggedIn ? "block" : "none" }}
-          >
-            MyPage
-          </Button>
-        </Link>
-        <Link href="/login" passHref>
-          <Button
-            color="inherit"
-            style={{ display: isLoggedIn ? "none" : "block" }}
-          >
-            로그인
-          </Button>
-        </Link>
-        <Button
-          color="inherit"
-          style={{ display: isLoggedIn ? "block" : "none" }}
-          onClick={handleLogoutDialogOpen}
-        >
-          로그아웃
-        </Button>
+        <div className={classes.buttonContainer}>
+          {isLoggedIn && (
+            <>
+              <Link href="/order" passHref>
+                <Button className={classes.button}>주문내역</Button>
+              </Link>
+              <Link href="/cartItems" passHref>
+                <Button className={classes.button}>카트목록</Button>
+              </Link>
+              <Link href="/paymentList" passHref>
+                <Button className={classes.button}>구매목록</Button>
+              </Link>
+              <Link href="/mypage" passHref>
+                <Button className={classes.button}>MyPage</Button>
+              </Link>
+              <Button className={classes.button} onClick={handleLogoutDialogOpen}>
+                로그아웃
+              </Button>
+            </>
+          )}
+
+          {!isLoggedIn && (
+            <Link href="/login" passHref>
+              <Button className={classes.button}>로그인</Button>
+            </Link>
+          )}
+        </div>
 
         <Dialog
           open={logoutDialogOpen}
@@ -117,12 +133,8 @@ const DesktopAppBar = () => {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleLogoutDialogClose} color="primary">
-              취소
-            </Button>
-            <Button onClick={handleLogout} color="primary" autoFocus>
-              확인
-            </Button>
+            <Button onClick={handleLogoutDialogClose} color="primary">취소</Button>
+            <Button onClick={handleLogout} color="primary" autoFocus>확인</Button>
           </DialogActions>
         </Dialog>
       </Toolbar>

--- a/AutumnShop/front/Autumnshop/components/DesktopAppBar.js
+++ b/AutumnShop/front/Autumnshop/components/DesktopAppBar.js
@@ -1,5 +1,4 @@
-import { AppBar, Toolbar, Typography, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
-import Link from "next/link";
+import { AppBar, Toolbar, Typography, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Popover, Link } from "@mui/material";
 import React, { useState, useEffect } from "react";
 import useLogout from "../hooks/useLogout";
 import { makeStyles } from "@mui/styles";
@@ -36,6 +35,7 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: "auto",
     marginRight: "40px",
     marginBottom: "10px",
+    alignItems: "center",
   },
   button: {
     fontSize: "18px",
@@ -53,10 +53,36 @@ const useStyles = makeStyles((theme) => ({
     textDecoration: "none",
     color: "inherit",
   },
+  popoverPaper: {
+    backgroundColor: "#000",
+    padding: "16px",
+    minWidth: "100px",
+    boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+    borderRadius: "8px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
+  nestedButton: {
+    padding: "6px 16px",
+    fontSize: "16px",
+    border: "2px solid #fff",
+    color: "#000",
+    backgroundColor: "#fff",
+    textAlign: "center",
+    marginBottom: "8px",
+    width: "150px",
+    borderRadius: "20px",
+    "&:hover": {
+      backgroundColor: "#f0f0f0",
+    },
+    fontWeight: "bold",
+  },
 }));
 
 const DesktopAppBar = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
   const {
     logoutDialogOpen,
     handleLogoutDialogOpen,
@@ -72,7 +98,6 @@ const DesktopAppBar = () => {
       setIsLoggedIn(!!loginInfo);
     };
 
-    // 컴포넌트 마운트 시 초기 로그인 상태 확인
     handleLoginStatusChange();
     window.addEventListener("loginStatusChanged", handleLoginStatusChange);
 
@@ -81,11 +106,21 @@ const DesktopAppBar = () => {
     };
   }, []);
 
+  const handlePopoverOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+
   return (
     <AppBar position="static" className={classes.appBar}>
       <Toolbar className={classes.toolbar}>
         <div className={classes.logoContainer}>
-          <Link href="/" passHref className={classes.link}>
+          <Link href="/welcome" className={classes.link}>
             <Typography variant="h6" className={classes.logo}>
               AutumnsMall
             </Typography>
@@ -93,18 +128,43 @@ const DesktopAppBar = () => {
         </div>
 
         <div className={classes.buttonContainer}>
+          <Link href="/products" className={classes.link}>
+            <Button className={classes.button}>상품목록</Button>
+          </Link>
           {isLoggedIn && (
             <>
-              <Link href="/order" passHref>
-                <Button className={classes.button}>주문내역</Button>
-              </Link>
-              <Link href="/cartItems" passHref>
-                <Button className={classes.button}>카트목록</Button>
-              </Link>
-              <Link href="/paymentList" passHref>
-                <Button className={classes.button}>구매목록</Button>
-              </Link>
-              <Link href="/mypage" passHref>
+              <Button className={classes.button} onClick={handlePopoverOpen}>
+                내역
+              </Button>
+
+              <Popover
+                open={open}
+                anchorEl={anchorEl}
+                onClose={handlePopoverClose}
+                anchorOrigin={{
+                  vertical: "bottom",
+                  horizontal: "center",
+                }}
+                transformOrigin={{
+                  vertical: "top",
+                  horizontal: "center",
+                }}
+                PaperProps={{
+                  className: classes.popoverPaper,
+                }}
+              >
+                <Link href="/order" className={classes.link}>
+                  <Button className={classes.nestedButton}>주문내역</Button>
+                </Link>
+                <Link href="/cartItems" className={classes.link}>
+                  <Button className={classes.nestedButton}>카트목록</Button>
+                </Link>
+                <Link href="/paymentList" className={classes.link}>
+                  <Button className={classes.nestedButton}>구매목록</Button>
+                </Link>
+              </Popover>
+
+              <Link href="/mypage" className={classes.link}>
                 <Button className={classes.button}>MyPage</Button>
               </Link>
               <Button className={classes.button} onClick={handleLogoutDialogOpen}>
@@ -114,7 +174,7 @@ const DesktopAppBar = () => {
           )}
 
           {!isLoggedIn && (
-            <Link href="/login" passHref>
+            <Link href="/login" className={classes.link}>
               <Button className={classes.button}>로그인</Button>
             </Link>
           )}

--- a/AutumnShop/front/Autumnshop/pages/login.js
+++ b/AutumnShop/front/Autumnshop/pages/login.js
@@ -106,7 +106,7 @@ const Login = () => {
 
       const loginInfo = await response.json();
       localStorage.setItem("loginInfo", JSON.stringify(loginInfo));
-      router.push("/");
+      router.push("/welcome");
 
       // 로그인 상태 변경 이벤트 발생
       const event = new Event("loginStatusChanged");

--- a/AutumnShop/front/Autumnshop/pages/login.js
+++ b/AutumnShop/front/Autumnshop/pages/login.js
@@ -29,13 +29,23 @@ const useStyles = makeStyles((theme) => ({
   textField: {
     backgroundColor: "#f5f5f5",
     borderRadius: "8px",
+    marginBottom: theme.spacing(2),
     '& .MuiOutlinedInput-root': {
       '& fieldset': {
-        border: "2px solid #ddd",
+        borderColor: "#ccc",
       },
       '&:hover fieldset': {
-        borderColor: "#000",
+        borderColor: "#888",
       },
+      '&.Mui-focused fieldset': {
+        borderColor: "#888",
+      },
+    },
+    '& .MuiInputLabel-root': {
+      color: "#888",
+    },
+    '& .MuiInputLabel-root.Mui-focused': {
+      color: "#888",
     },
   },
   loginButton: {
@@ -58,6 +68,9 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
     "&:hover": {
       backgroundColor: "#f0f0f0",
+    },
+    "&:focus": {
+      backgroundColor: "#e0e0e0",
     },
   },
   errorMessage: {

--- a/AutumnShop/front/Autumnshop/pages/welcome.js
+++ b/AutumnShop/front/Autumnshop/pages/welcome.js
@@ -1,10 +1,104 @@
 import React, { useEffect, useState } from "react";
+import { Button } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 
-const WelcomePage = () => {
+const useStyles = makeStyles({
+  container: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    height: "100vh",
+    width: "100%",
+    overflow: "hidden",
+  },
+  innerContainer: {
+    position: "relative",
+    width: "600px",
+    height: "900px",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  sectionTitle: {
+    width: "100%",
+    marginLeft: "20px",
+    marginBottom: "20px",
+    fontSize: "32px",
+    fontWeight: "bold",
+  },
+  subTitle: {
+    width: "100%",
+    marginLeft: "20px",
+    marginBottom: "40px",
+    fontSize: "24px",
+    fontWeight: "normal",
+  },
+  imageContainer: {
+    position: "relative",
+    width: "100%",
+    height: "100%",
+    overflow: "hidden",
+    marginTop: "-30px",
+  },
+  productImage: {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    cursor: "pointer",
+  },
+  buttonsContainer: {
+    marginTop: "20px",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  button: {
+    margin: "5px",
+    width: "140px",
+    height: "30px",
+    backgroundColor: "white",
+    border: "3px solid black",
+    color: "black",
+    textTransform: "none",
+    borderRadius: "50px",
+    transition: "background-color 0.3s, border-color 0.3s",
+    outline: "none",
+    "&:hover": {
+      backgroundColor: "white",
+      borderColor: "black",
+      color: "black",
+    },
+    "&:focus": {
+      backgroundColor: "white",
+      borderColor: "black",
+      color: "black",
+      outline: "none",
+    },
+    "&:active": {
+      backgroundColor: "white",
+      borderColor: "black",
+      color: "black",
+    },
+  },
+});
+
+const MainPage = () => {
+  const [mainProducts, setMainProducts] = useState([]);
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+  const classes = useStyles();
+
+  // 상품 데이터 가져오기 및 마일리지 만료 처리
   useEffect(() => {
     const mileageExpire = async () => {
       try {
         const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+        if (!loginInfo || !loginInfo.accessToken) {
+          console.error("로그인 정보가 없습니다.");
+          return;
+        }
+
+        // 마일리지 만료 처리
         const getMileageExpireResponse = await fetch(
           "http://localhost:8080/mileage/expire",
           {
@@ -14,20 +108,99 @@ const WelcomePage = () => {
             },
           }
         );
-    
+
+        if (!getMileageExpireResponse.ok) {
+          console.error("마일리지 만료 처리 실패");
+        }
+
+        // 상품 데이터 가져오기
+        const response = await fetch("http://localhost:8080/products");
+        const data = await response.json();
+        setMainProducts(data.content);
       } catch (error) {
-        console.error("멤버 정보를 불러오지 못했습니다.");
+        console.error("상품 정보를 불러오지 못했습니다.");
       }
     };
 
     mileageExpire();
   }, []);
 
+  // 자동 이미지 전환 처리
+  useEffect(() => {
+    if (mainProducts.length === 0) return; // 상품이 없으면 자동 이미지 전환 시작하지 않음
+
+    const intervalId = setInterval(() => {
+      setCurrentImageIndex((prevIndex) =>
+        prevIndex === mainProducts.length - 1 ? 0 : prevIndex + 1
+      );
+    }, 3000); // 이미지 전환 시간
+
+    return () => clearInterval(intervalId); // 컴포넌트 언마운트 시 interval 해제
+  }, [mainProducts]); // mainProducts가 변경될 때마다 자동 이미지 전환 시작
+
+  const handleImageChange = (index) => {
+    setCurrentImageIndex(index); // 이미지 인덱스를 수동으로 변경
+  };
+
+  const handleImageClick = (id) => {
+    window.location.href = `http://localhost:3000/product/${id}`;
+  };
+
   return (
-    <div>
-      <h1>환영합니다.</h1>
+    <div className={classes.container}>
+      <div className={classes.innerContainer}>
+        <div className={classes.sectionTitle}>추천 상품</div>
+        <div className={classes.subTitle}>요즘 잘나가는 인기 상품</div>
+
+        {mainProducts.length > 0 && (
+          <div className={classes.imageContainer}>
+            <h2 style={{ textAlign: "center" }}>
+              {mainProducts[currentImageIndex]?.name}
+            </h2>
+
+            <div
+              style={{
+                display: "flex",
+                transition: "transform 0.5s ease-in-out",
+                transform: `translateX(-${currentImageIndex * 600}px)`,
+                width: `${mainProducts.length * 600}px`,
+              }}
+            >
+              {mainProducts.map((product, index) => (
+                <div
+                  key={index}
+                  style={{
+                    width: "600px",
+                    height: "600px",
+                    border: "5px solid black",
+                    borderRadius: "10px",
+                  }}
+                >
+                  <img
+                    src={product.imageUrl}
+                    alt={product.name}
+                    className={classes.productImage}
+                    onClick={() => handleImageClick(product.id)}
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className={classes.buttonsContainer}>
+              {mainProducts.map((_, index) => (
+                <Button
+                  key={index}
+                  variant="outlined"
+                  className={classes.button}
+                  onClick={() => handleImageChange(index)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 };
 
-export default WelcomePage;
+export default MainPage;


### PR DESCRIPTION
1. AppBar의 디자인을 다른 페이지와 비슷하게 검은색 배경느낌으로 하였음
2. 로고를 가운데로 옮기고, 이미지를 삭제하였음
3. 상품목록, 카트목록, 구매목록을 '내역' 버튼으로 옮겨 내역 버튼을 누르면 세 버튼이 아래에 보여지게 함ㄴ
4. 메인 페이지는 추천 물건들만 일단 보여지게 하였음
4.1 추천 물건들은 특정 시간 혹은 아래의 버튼을 통해 슬라이드되는 형식임
5. 로그인 시, 로고 버튼을 누를 시 메인 페이지를 '/'이 아닌 '/welcome'으로 이동되게 설정하여 로그인 시 마일리지 만료 기능도 같이 하도록 함
