### PR TITLE
물품 상세 페이지 로그아웃 시 비 렌더링 문제 해결 및 앱바 배경이 맞지않아 높이 약간 조정

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/welcome.js
+++ b/AutumnShop/front/Autumnshop/pages/welcome.js
@@ -33,7 +33,7 @@ const useStyles = makeStyles({
     left: 0,
     right: 0,
     zIndex: 1100,
-    height: "64px",
+    height: "56px",
     backgroundColor: "#333",
   },
   tab: {


### PR DESCRIPTION
1. 물품을 불러오는 것과 즐겨찾기 상태를 불러오는 것 두 개를 분리함
2. 물품을 불러올 때 굳이 로그인한 사용자의 정보가 필요하지 않았음에도 불러오던 점 수정
3. 로그인이 필요한 '즐겨찾기 추가', '최근 본 상품 목록' 버튼을 누르면, 비 로그인 시 alert창으로 리턴하도록 함
4. 비 로그인 시 상품평을 작성하고자 했을 때 확인 창을 출력하여 '예'를 누르면 login창으로, '아니오'를 누르면 작성 취소하도록 함
5. 상품평을 작성할 때 별점과 상품평이 있어야 작성되지만, 만약을 위해 예외처리를 추가함