### PR TITLE
#84

### DIFF
--- a/AutumnShop/build.gradle
+++ b/AutumnShop/build.gradle
@@ -43,6 +43,16 @@ dependencies {
 
     // dto validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // mapper
+    implementation 'org.mapstruct:mapstruct:1.5.3.Final' // MapStruct 의존성 추가
+    compileOnly 'org.mapstruct:mapstruct-processor:1.5.3.Final' // MapStruct Processor 의존성 추가 (빌드 시 코드 생성용)
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final' // Annotation Processor 의존성 추가
+
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorPath = configurations.annotationProcessor
 }
 
 tasks.named('test') {

--- a/AutumnShop/build.gradle
+++ b/AutumnShop/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
 tasks.withType(JavaCompile) {
     options.annotationProcessorPath = configurations.annotationProcessor
+    options.compilerArgs << "-Xlint:unchecked"
 }
 
 tasks.named('test') {

--- a/AutumnShop/front/Autumnshop/pages/order.js
+++ b/AutumnShop/front/Autumnshop/pages/order.js
@@ -124,7 +124,7 @@ function OrderDetails() {
     <div className={classes.cartContainer}>
       {payment && payment.map((paymentitem, index) => (
         <div key={index}>
-          <h2>주문번호 : {orderid[index]}</h2>
+          <h2>주문번호 : {index + 1}</h2>
           <table className={classes.cartTable}>
             <thead>
               <tr className={classes.headerRow}>

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/controller/CartApiController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/controller/CartApiController.java
@@ -19,7 +19,7 @@ public class CartApiController {
     private final CartService cartService;
     @PostMapping
     public Cart addCart(@IfLogin @RequestBody AddCartDto addCartDto) {
-        Cart cart = cartService.addCart(addCartDto.getMemberId());
+        Cart cart = cartService.addCart(addCartDto);
         return cart;
     }
     @GetMapping("/{memberId}") // http://localhost:8080/carts/{memberId}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/mapper/CartItemMapper.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/mapper/CartItemMapper.java
@@ -1,19 +1,18 @@
 package com.example.AutumnMall.Cart.mapper;
 
-import com.example.AutumnMall.Cart.domain.Cart;
 import com.example.AutumnMall.Cart.domain.CartItem;
 import com.example.AutumnMall.Cart.dto.AddCartItemDto;
-import com.example.AutumnMall.Product.domain.Product;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
-public abstract class CartItemMapper {
+public interface CartItemMapper {
+
     @Mapping(target = "cart", ignore = true)
     @Mapping(target = "product", ignore = true)
     @Mapping(source = "quantity", target = "quantity")
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "modifiedAt", ignore = true) // CartItems는 별도로 처리
-    public abstract CartItem addCartItemDtoToCartItem(AddCartItemDto addCartItemDto);
+    CartItem addCartItemDtoToCartItem(AddCartItemDto addCartItemDto);
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/mapper/CartItemMapper.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/mapper/CartItemMapper.java
@@ -1,0 +1,19 @@
+package com.example.AutumnMall.Cart.mapper;
+
+import com.example.AutumnMall.Cart.domain.Cart;
+import com.example.AutumnMall.Cart.domain.CartItem;
+import com.example.AutumnMall.Cart.dto.AddCartItemDto;
+import com.example.AutumnMall.Product.domain.Product;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public abstract class CartItemMapper {
+    @Mapping(target = "cart", ignore = true)
+    @Mapping(target = "product", ignore = true)
+    @Mapping(source = "quantity", target = "quantity")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "modifiedAt", ignore = true) // CartItems는 별도로 처리
+    public abstract CartItem addCartItemDtoToCartItem(AddCartItemDto addCartItemDto);
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/mapper/CartMapper.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/mapper/CartMapper.java
@@ -5,9 +5,9 @@ import com.example.AutumnMall.Cart.dto.AddCartDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-
 @Mapper(componentModel = "spring")
-public abstract class CartMapper {
+public interface CartMapper {
+
     // AddCartDto -> Cart 엔티티로 매핑
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "member", ignore = true)
@@ -15,5 +15,5 @@ public abstract class CartMapper {
     @Mapping(target = "modifiedAt", ignore = true)
     @Mapping(target = "date", ignore = true)
     @Mapping(target = "cartItems", ignore = true) // CartItems는 별도로 처리
-    public abstract Cart addCartDtoToCart(AddCartDto addCartDto);
+    Cart addCartDtoToCart(AddCartDto addCartDto);
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/mapper/CartMapper.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/mapper/CartMapper.java
@@ -1,0 +1,19 @@
+package com.example.AutumnMall.Cart.mapper;
+
+import com.example.AutumnMall.Cart.domain.Cart;
+import com.example.AutumnMall.Cart.dto.AddCartDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+
+@Mapper(componentModel = "spring")
+public abstract class CartMapper {
+    // AddCartDto -> Cart 엔티티로 매핑
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "member", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "modifiedAt", ignore = true)
+    @Mapping(target = "date", ignore = true)
+    @Mapping(target = "cartItems", ignore = true) // CartItems는 별도로 처리
+    public abstract Cart addCartDtoToCart(AddCartDto addCartDto);
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/service/CartItemService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/service/CartItemService.java
@@ -1,5 +1,6 @@
 package com.example.AutumnMall.Cart.service;
 
+import com.example.AutumnMall.Cart.mapper.CartItemMapper;
 import com.example.AutumnMall.Member.domain.Member;
 import com.example.AutumnMall.Product.domain.Product;
 import com.example.AutumnMall.Cart.dto.ResponseGetCartItemDto;
@@ -27,6 +28,8 @@ public class CartItemService {
     private final ProductRepository productRepository;
     private final MemberRepository memberRepository;
 
+    private final CartItemMapper cartItemMapper;
+
 
     @Transactional
     public CartItem addCartItem(AddCartItemDto addCartItemDto) {
@@ -34,9 +37,8 @@ public class CartItemService {
             Cart cart = cartRepository.findById(addCartItemDto.getCartId()).orElseThrow();
             Product product = productRepository.findById(addCartItemDto.getProductId()).orElseThrow();
 
-            CartItem cartItem = new CartItem();
+            CartItem cartItem = cartItemMapper.addCartItemDtoToCartItem(addCartItemDto);
             cartItem.setCart(cart);
-            cartItem.setQuantity(addCartItemDto.getQuantity());
             cartItem.setProduct(product);
 
             CartItem savedCartItem = cartItemRepository.save(cartItem);

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Member/domain/Member.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Member/domain/Member.java
@@ -86,6 +86,9 @@ public class Member extends Auditable {
     }
 
     public void addRole(Role role) {
+        if (roles == null) {
+            roles = new HashSet<>();  // roles가 null이라면 새로 초기화
+        }
         roles.add(role);
     }
 

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Member/mapper/MemberMapper.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Member/mapper/MemberMapper.java
@@ -1,0 +1,73 @@
+package com.example.AutumnMall.Member.mapper;
+
+import com.example.AutumnMall.Member.domain.Member;
+import com.example.AutumnMall.Member.dto.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+
+@Mapper(componentModel = "spring")
+public interface MemberMapper {
+
+    @Mapping(source = "memberId", target = "memberId")
+    @Mapping(source = "name", target = "nickname")
+    @Mapping(source = "accessToken", target = "accessToken")
+    @Mapping(source = "refreshToken", target = "refreshToken")
+    MemberLoginResponseDto toLoginResponseDtoToMember(Long memberId, String name, String accessToken, String refreshToken);
+
+    @Mapping(source = "memberId", target = "memberId")
+    @Mapping(source = "email", target = "email")
+    @Mapping(source = "name", target = "name")
+    @Mapping(source = "regdate", target = "regdate")
+    MemberSignupResponseDto memberSignupResponseDtoToMember(Member member);
+
+    @Mapping(target = "roles", ignore = true)
+    @Mapping(source = "name", target= "name")
+    @Mapping(source = "email", target= "email")
+    // 비밀번호는 서비스에서 인코딩 후 설정
+    @Mapping(source = "birthYear", target = "birthYear", qualifiedByName = "stringToInteger")
+    @Mapping(source = "birthMonth", target = "birthMonth", qualifiedByName = "stringToInteger")
+    @Mapping(source = "birthDay", target = "birthDay", qualifiedByName = "stringToInteger")
+    // DB에서 자동 생성되므로 무시
+    @Mapping(source = "gender", target = "gender")
+    @Mapping(source = "phone", target = "phone")
+    @Mapping(source = "roadAddress", target = "roadAddress")
+    @Mapping(source = "zipCode", target = "zipCode")
+    @Mapping(source = "detailAddress", target = "detailAddress")
+    @Mapping(target = "memberId", ignore = true)
+    @Mapping(target = "regdate", ignore = true)
+    @Mapping(target = "mileages", ignore = true)
+    @Mapping(target = "totalMileage", ignore = true)
+    @Mapping(target = "favorites", ignore = true)
+    @Mapping(target = "recentProducts", ignore = true)
+    Member memberSignupDtoToMember(MemberSignupDto memberSignupDto);
+
+    @Mapping(source = "name", target = "name", defaultValue = "null")
+    @Mapping(source = "email", target = "email", defaultValue = "null")
+    @Mapping(source = "birthYear", target = "birthYear", qualifiedByName = "stringToInteger")
+    @Mapping(source = "birthMonth", target = "birthMonth", qualifiedByName = "stringToInteger")
+    @Mapping(source = "birthDay", target = "birthDay", qualifiedByName = "stringToInteger")
+    @Mapping(source = "gender", target = "gender", defaultValue = "null")
+    @Mapping(source = "phone", target = "phone", defaultValue = "null")
+    @Mapping(source = "roadAddress", target = "roadAddress", defaultValue = "null")
+    @Mapping(source = "zipCode", target = "zipCode", defaultValue = "null")
+    @Mapping(source = "detailAddress", target = "detailAddress", defaultValue = "null")
+    @Mapping(target = "memberId", ignore = true)
+    @Mapping(target = "password", ignore = true)
+    @Mapping(target = "regdate", ignore = true)
+    @Mapping(target = "roles", ignore = true)
+    @Mapping(target = "mileages", ignore = true)
+    @Mapping(target = "totalMileage", ignore = true)
+    @Mapping(target = "favorites", ignore = true)
+    @Mapping(target = "recentProducts", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "modifiedAt", ignore = true)
+    Member updateMemberFromDto(MemberUpdateDto memberUpdateDto, @MappingTarget Member member);
+
+    // String → Integer 변환 메서드
+    @Named("stringToInteger")
+    default Integer stringToInteger(String value) {
+        return value != null ? Integer.parseInt(value) : null;
+    }
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Member/service/MemberService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.example.AutumnMall.Member.domain.Member;
 import com.example.AutumnMall.Member.domain.Role;
 import com.example.AutumnMall.Member.dto.MemberSignupDto;
 import com.example.AutumnMall.Member.dto.MemberUpdateDto;
+import com.example.AutumnMall.Member.mapper.MemberMapper;
 import com.example.AutumnMall.Member.repository.MemberRepository;
 import com.example.AutumnMall.Member.repository.RoleRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,8 @@ public class MemberService {
     private final RoleRepository roleRepository;
     private final PasswordEncoder passwordEncoder;
 
+    private final MemberMapper memberMapper;
+
     @Transactional(readOnly = true)
     public Member findByEmail(String email){
         try {
@@ -35,18 +38,9 @@ public class MemberService {
     @Transactional
     public Member addMember(MemberSignupDto memberSignupDto) {
         try {
-            Member member = new Member();
-            member.setName(memberSignupDto.getName());
-            member.setEmail(memberSignupDto.getEmail());
+            Member member = memberMapper.memberSignupDtoToMember(memberSignupDto);
+            // mapper를 사용하면 평문으로 저장되기에 서비스단에서 처리
             member.setPassword(passwordEncoder.encode(memberSignupDto.getPassword()));
-            member.setBirthYear(Integer.parseInt(memberSignupDto.getBirthYear()));
-            member.setBirthMonth(Integer.parseInt(memberSignupDto.getBirthMonth()));
-            member.setBirthDay(Integer.parseInt(memberSignupDto.getBirthDay()));
-            member.setGender(memberSignupDto.getGender());
-            member.setPhone(memberSignupDto.getPhone());
-            member.setRoadAddress(memberSignupDto.getRoadAddress());
-            member.setZipCode(memberSignupDto.getZipCode());
-            member.setDetailAddress(memberSignupDto.getDetailAddress());
 
             Optional<Role> userRole = roleRepository.findByName("ROLE_USER");
             member.addRole(userRole.get());
@@ -89,7 +83,7 @@ public class MemberService {
             Member member = existingMember.get();
 
             // 수정할 정보만 업데이트
-            updateMemberWrite(member, memberUpdateDto);
+            memberMapper.updateMemberFromDto(memberUpdateDto, member);
 
             // 로그 추가: 회원 정보 수정
             log.info("회원 {}의 정보가 수정되었습니다: {}", member.getEmail(), member);
@@ -101,6 +95,7 @@ public class MemberService {
         }
     }
 
+    // mapper를 사용할 경우 평문으로 저장되므로 서비스단에서만 처리
     @Transactional
     public Member updateMemberPassword(Long memberId, String newPassword){
         try {
@@ -115,41 +110,6 @@ public class MemberService {
         }catch(IllegalArgumentException e){
             log.error("멤버 패스워드 업데이트 실패 : {}", e.getMessage(), e);
             throw e;
-        }
-    }
-
-    // 멤버의 업데이트할 정보만 갱신
-    private void updateMemberWrite(Member member, MemberUpdateDto memberUpdateDto) {
-        if (memberUpdateDto.getName() != null) {
-            member.setName(memberUpdateDto.getName());
-        }
-        if (memberUpdateDto.getEmail() != null) {
-            member.setEmail(memberUpdateDto.getEmail());
-        }
-
-        if (memberUpdateDto.getBirthYear() != null) {
-            member.setBirthYear(Integer.parseInt(memberUpdateDto.getBirthYear()));
-        }
-        if (memberUpdateDto.getBirthMonth() != null) {
-            member.setBirthMonth(Integer.parseInt(memberUpdateDto.getBirthMonth()));
-        }
-        if (memberUpdateDto.getBirthDay() != null) {
-            member.setBirthDay(Integer.parseInt(memberUpdateDto.getBirthDay()));
-        }
-        if (memberUpdateDto.getGender() != null) {
-            member.setGender(memberUpdateDto.getGender());
-        }
-        if (memberUpdateDto.getPhone() != null) {
-            member.setPhone(memberUpdateDto.getPhone());
-        }
-        if (memberUpdateDto.getRoadAddress() != null) {
-            member.setRoadAddress(memberUpdateDto.getRoadAddress());
-        }
-        if (memberUpdateDto.getZipCode() != null) {
-            member.setZipCode(memberUpdateDto.getZipCode());
-        }
-        if (memberUpdateDto.getDetailAddress() != null) {
-            member.setDetailAddress(memberUpdateDto.getDetailAddress());
         }
     }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/controller/ReviewController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/controller/ReviewController.java
@@ -40,8 +40,7 @@ public class ReviewController {
         ReviewResponseDto responseDto = reviewService.addReview(
                 loginUserDto.getMemberId(),
                 productId,
-                reviewRequestDto.getContent(),
-                reviewRequestDto.getRating());
+                reviewRequestDto);
 
         return ResponseEntity.ok(new ResponseWrapper<>(true, responseDto, "상품평이 등록되었습니다."));
     }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/mapper/ProductMapper.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/mapper/ProductMapper.java
@@ -1,0 +1,24 @@
+package com.example.AutumnMall.Product.mapper;
+
+import com.example.AutumnMall.Product.domain.Product;
+import com.example.AutumnMall.Product.dto.AddProductDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ProductMapper {
+
+    @Mapping(target = "category", ignore = true)
+    @Mapping(source = "price", target = "price")
+    @Mapping(source = "description", target = "description")
+    @Mapping(source = "imageUrl", target = "imageUrl")
+    @Mapping(source = "title", target = "title")
+    @Mapping(target = "rating.rate", ignore = true)
+    @Mapping(target = "rating.count", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "modifiedAt", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "favorites", ignore = true)
+    @Mapping(target = "recentProducts", ignore = true)
+    Product addProductDtoToProduct(AddProductDto addProductDto);
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ProductService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ProductService.java
@@ -4,6 +4,7 @@ import com.example.AutumnMall.Product.domain.Category;
 import com.example.AutumnMall.Product.domain.Product;
 import com.example.AutumnMall.Product.domain.Rating;
 import com.example.AutumnMall.Product.dto.AddProductDto;
+import com.example.AutumnMall.Product.mapper.ProductMapper;
 import com.example.AutumnMall.Product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,13 +22,15 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final CategoryService categoryService;
 
+    private final ProductMapper productMapper;
+
     @Transactional
     public Product addProduct(AddProductDto addProductDto) {
         try {
             log.info("상품 추가 요청. 상품명: {}", addProductDto.getTitle());  // 상품 추가 요청 로그
 
             Category category = categoryService.getCategory(addProductDto.getCategoryId());
-            Product product = new Product();
+            Product product = productMapper.addProductDtoToProduct(addProductDto);
             product.setCategory(category);
             product.setPrice(addProductDto.getPrice());
             product.setDescription(addProductDto.getDescription());

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ReviewService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ReviewService.java
@@ -4,6 +4,7 @@ import com.example.AutumnMall.Member.domain.Member;
 import com.example.AutumnMall.Product.domain.Product;
 import com.example.AutumnMall.Product.domain.Rating;
 import com.example.AutumnMall.Product.domain.Review;
+import com.example.AutumnMall.Product.dto.ReviewRequestDto;
 import com.example.AutumnMall.Product.dto.ReviewResponseDto;
 import com.example.AutumnMall.Member.repository.MemberRepository;
 import com.example.AutumnMall.Product.repository.ProductRepository;
@@ -27,7 +28,7 @@ public class ReviewService {
     private final MemberRepository memberRepository;
 
     // 상품명 등록
-    public ReviewResponseDto addReview(Long memberId, Long productId, String content, int rating){
+    public ReviewResponseDto addReview(Long memberId, Long productId, ReviewRequestDto reviewRequestDto){
         try {
             log.info("리뷰 등록 요청. 회원 ID: {}, 상품 ID: {}", memberId, productId);  // 리뷰 등록 요청 로그
 
@@ -45,8 +46,8 @@ public class ReviewService {
             Review review = Review.builder()
                     .product(product)
                     .member(member)
-                    .content(content)
-                    .rating(rating)
+                    .content(reviewRequestDto.getContent())
+                    .rating(reviewRequestDto.getRating())
                     .createdAt(LocalDateTime.now())
                     .build();
             reviewRepository.save(review);


### PR DESCRIPTION
close #84 

Cart 폴더만 mapper를 사용하여 엔티티 변환함
1. 사용법 :
- 외래키같은 경우 mapper에서 설정하기 보다 기존처럼 서비스에서 설정하고, mapper에서 ignore 하기
- dto에서 도메인 갈 때 굳이 mapper로 안 할 애들은 ignore
- CartItem의 quantity와 같이 mapper에서 설정했으면 서비스에서 빼도 됨

다른 파일 mapper 추가 ( 단, 몇몇개는 제외하였음 )
1. product 파일의 category는 하나밖에 없어서 비효율적이며, reviewRequest는 mapper 후 builder로 다른 필드들을 설정할 때 포함하여 총  두 번 설정하기에 비효율적임
    reviewResponseDto는 자체적으로 set하기 때문에 굳이 할 필요가 없다고 생각됨 ( 추후, 다른 Response도 똑같이 수정 예정)
2. Payment 파일의 Order는 하나밖에 없어서 비효율적이며, payment는 quantity가 리스트로 받아져있고, cartId는 payment에 없는 속성이기에
    올바르게 적용할려면 매개변수에서 받고 orderId만 해야되지만 그렇게 될 경우 매우 비효율적임
3. Member 파일의 checkPassword, AddMileage, RefreshToken, PasswordChange, memberLoginDto는 mapper를 통해 형변환할 필요가 없었음

+

주문번호가 잘못되던 점 수정
