### PR TITLE
CustomBeanUtils 기능 구현 및 프론트 엔드 수정

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/cartItems.js
+++ b/AutumnShop/front/Autumnshop/pages/cartItems.js
@@ -117,7 +117,6 @@ async function getCartItem(loginInfo, setCartItem, setCartMemberId, setUpdatedQu
     cartItemsData.map(async (item) => {
       const productResponse = await fetch(`http://localhost:8080/products/${item.productId}`);
       const productData = await productResponse.json();
-      console.log(productData);
       return productData.rating.count;
     })
   );
@@ -191,7 +190,7 @@ const CartItems = () => {
 
   // 카트에 저장된 아이템들의 총 가격
   cartItems.forEach((item, index) => {
-    totalPrice += item.productPrice * updatedQuantity[index];
+    totalPrice += item.price * updatedQuantity[index];
   });
 
   const QuantityChange = (event, index) => {
@@ -228,9 +227,9 @@ const CartItems = () => {
           {cartItems.map((item, index) => (
             <tr key={item.id} className={classes.cartItem}>
               <td className={classes.cartItemCell}>{index + 1}</td>
-              <td className={classes.cartItemCell}>{item.productTitle}</td>
-              <td className={classes.cartItemCell}>{item.productPrice}</td>
-              <td className={classes.cartItemCell}>{item.productDescription}</td>
+              <td className={classes.cartItemCell}>{item.title}</td>
+              <td className={classes.cartItemCell}>{item.price}</td>
+              <td className={classes.cartItemCell}>{item.description}</td>
               <td className={classes.cartItemCell}>
                 <select
                   className={classes.quantityInput}

--- a/AutumnShop/front/Autumnshop/pages/order.js
+++ b/AutumnShop/front/Autumnshop/pages/order.js
@@ -139,8 +139,8 @@ function OrderDetails() {
             <tbody>
               {paymentitem.map((item, idx) => (
                 <tr key={idx} className={classes.detailRow}>
-                  <td className={classes.detailCell}>{item.productTitle}</td>
-                  <td className={classes.detailCell}>{item.productPrice}</td>
+                  <td className={classes.detailCell}>{item.title}</td>
+                  <td className={classes.detailCell}>{item.price}</td>
                   <td className={classes.detailCell}>{item.productRate}</td>
                   <td className={classes.detailCell}>{item.quantity}</td>
                   <td className={classes.detailCell}>{item.date}</td>

--- a/AutumnShop/front/Autumnshop/pages/paymentList/[param].js
+++ b/AutumnShop/front/Autumnshop/pages/paymentList/[param].js
@@ -139,12 +139,33 @@ const paymentList = () => {
   useEffect(() => {
     let itemTotalPrice = 0;
     if (paymentItems && paymentItems.content) {
-      paymentItems.content.forEach((item, index) => {
-        itemTotalPrice += item.productPrice * item.quantity;
+      // 날짜를 기준으로 정렬 (오름차순), 날짜가 같다면 id 순으로 정렬
+      const sortedItems = [...paymentItems.content].sort((a, b) => {
+        const dateA = new Date(a.date);
+        const dateB = new Date(b.date);
+  
+        // 날짜가 다르면 날짜 기준으로 오름차순 정렬
+        if (dateA - dateB !== 0) {
+          return dateA - dateB;
+        }
+  
+        // 날짜가 같으면 id 순으로 오름차순 정렬
+        return a.id - b.id;
       });
+  
+      // 정렬된 항목으로 가격 합계 계산
+      sortedItems.forEach((item) => {
+        itemTotalPrice += item.price * item.quantity;
+      });
+  
+      // 상태가 변경된 경우에만 업데이트
+      if (JSON.stringify(paymentItems.content) !== JSON.stringify(sortedItems)) {
+        setPaymentItems({ ...paymentItems, content: sortedItems });
+      }
+      setTotalPrice(itemTotalPrice);
     }
-    setTotalPrice(itemTotalPrice);
-  }, [paymentItems]);
+  }, [paymentItems.content]); // content만 의존성 배열에 추가
+  
 
   const totalPages = paymentItems.totalPages;
 
@@ -169,8 +190,8 @@ const paymentList = () => {
             paymentItems.content.map((item, index) => (
               <tr key={item.id} className={classes.tableRow}>
                 <td className={classes.tableCell}>{index + 1}</td>
-                <td className={classes.tableCell}>{item.productTitle}</td>
-                <td className={classes.tableCell}>{item.productPrice}</td>
+                <td className={classes.tableCell}>{item.title}</td>
+                <td className={classes.tableCell}>{item.price}</td>
                 <td className={classes.tableCell}>{item.productRate}</td>
                 <td className={classes.tableCell}>{item.quantity}</td>
                 <td className={classes.tableCell}>

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/dto/ResponseGetCartItemDto.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/dto/ResponseGetCartItemDto.java
@@ -8,20 +8,10 @@ import lombok.Setter;
 public class ResponseGetCartItemDto {
     private Long id;
     private Long productId;
-    private String productTitle;
-    private Double productPrice;
-    private String productDescription;
+    private String title;
+    private Double price;
+    private String description;
     private String imageUrl;
     private int quantity;
-
-    public ResponseGetCartItemDto(Long id, Long productId, String productTitle, double productPrice, String productDescription, int quantity, String imageUrl){
-        this.id = id;
-        this.productId = productId;
-        this.productTitle = productTitle;
-        this.productPrice = productPrice;
-        this.productDescription = productDescription;
-        this.quantity = quantity;
-        this.imageUrl = imageUrl;
-    }
 
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Payment.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Payment.java
@@ -20,8 +20,8 @@ public class Payment extends Auditable {
 
     private String imageUrl;
     private Long productId;
-    private Double productPrice;
-    private String productTitle;
+    private Double price;
+    private String title;
     private Double productRate;
     private int quantity;
 

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
@@ -81,6 +81,7 @@ public class PaymentService {
                 // payment와 product의 같은 속성만 그대로 복사 ( price, title )
                 Payment userPayment = new Payment();
                 customBeanUtils.copyProperties(product, userPayment);
+                userPayment.setId(null);
                 userPayment.setProductId(product.getId());
                 userPayment.setProductRate(product.getRating().getRate());
                 userPayment.setQuantity(quantity);

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
@@ -10,8 +10,10 @@ import com.example.AutumnMall.Payment.repository.OrderRepository;
 import com.example.AutumnMall.Payment.repository.PaymentRepository;
 import com.example.AutumnMall.Product.domain.Product;
 import com.example.AutumnMall.Product.repository.ProductRepository;
+import com.example.AutumnMall.utils.CustomBean.CustomBeanUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -32,6 +34,9 @@ public class PaymentService {
     private final MemberRepository memberRepository;
     private final OrderRepository orderRepository;
     private final ProductRepository productRepository;
+
+    @Autowired
+    private final CustomBeanUtils customBeanUtils;
 
     // 추후 Builder를 통해 리팩토링 할 예정
     @Transactional
@@ -62,6 +67,8 @@ public class PaymentService {
                 int quantity = quantityIterator.next();
 
                 Product product = cartItem.getProduct();
+                System.out.println(product.getPrice());
+
 
                 if(product.getRating().getCount() < quantity){
                     log.error("구매 수량 {}가 잔여 수량보다 많습니다. 상품: {}", quantity, product.getTitle());  // 오류 로그
@@ -71,11 +78,10 @@ public class PaymentService {
                 product.getRating().setCount(product.getRating().getCount() - quantity);
                 productRepository.save(product);
 
+                // payment와 product의 같은 속성만 그대로 복사 ( price, title )
                 Payment userPayment = new Payment();
-                userPayment.setImageUrl(product.getImageUrl());
+                customBeanUtils.copyProperties(product, userPayment);
                 userPayment.setProductId(product.getId());
-                userPayment.setProductPrice(product.getPrice());
-                userPayment.setProductTitle(product.getTitle());
                 userPayment.setProductRate(product.getRating().getRate());
                 userPayment.setQuantity(quantity);
                 userPayment.setMember(member);

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/dto/ReviewResponseDto.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/dto/ReviewResponseDto.java
@@ -19,13 +19,4 @@ public class ReviewResponseDto {
     private String authorName;
     private LocalDateTime createdAt;
     private Long memberId;
-
-    public ReviewResponseDto(Review review){
-        this.id = review.getId();
-        this.content = review.getContent();
-        this.rating = review.getRating();
-        this.authorName = review.getMember().getName();
-        this.createdAt = review.getCreatedAt();
-        this.memberId = review.getMember().getMemberId();
-    }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ProductService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ProductService.java
@@ -6,8 +6,10 @@ import com.example.AutumnMall.Product.domain.Rating;
 import com.example.AutumnMall.Product.dto.AddProductDto;
 import com.example.AutumnMall.Product.mapper.ProductMapper;
 import com.example.AutumnMall.Product.repository.ProductRepository;
+import com.example.AutumnMall.utils.CustomBean.CustomBeanUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -22,7 +24,11 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final CategoryService categoryService;
 
+    @Autowired
     private final ProductMapper productMapper;
+
+    @Autowired
+    private final CustomBeanUtils customBeanUtils;
 
     @Transactional
     public Product addProduct(AddProductDto addProductDto) {
@@ -31,11 +37,14 @@ public class ProductService {
 
             Category category = categoryService.getCategory(addProductDto.getCategoryId());
             Product product = productMapper.addProductDtoToProduct(addProductDto);
+
+            // CustomBeanUtils로 Product 속성 복사 ( price, imageUrl, description, title )
+            customBeanUtils.copyProperties(addProductDto, product);  // 기본 필드 복사
+
+            // 복잡한 필드나 추가적인 설정은 수동으로 처리
             product.setCategory(category);
-            product.setPrice(addProductDto.getPrice());
-            product.setDescription(addProductDto.getDescription());
-            product.setImageUrl(addProductDto.getImageUrl());
-            product.setTitle(addProductDto.getTitle());
+
+            // Rating 객체 초기화
             Rating rating = new Rating();
             rating.setRate(0.0);
             rating.setCount(0);

--- a/AutumnShop/src/main/java/com/example/AutumnMall/utils/CustomBean/CustomBeanUtils.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/utils/CustomBean/CustomBeanUtils.java
@@ -1,0 +1,48 @@
+package com.example.AutumnMall.utils.CustomBean;
+
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+
+@Component
+public class CustomBeanUtils {
+
+    /**
+     * source 객체의 null이 아닌 프로퍼티를 destination 객체로 복사
+     * @param source 복사할 원본 객체
+     * @param destination 복사할 대상 객체
+     * @return 업데이트된 destination 객체
+     */
+    public <T, U> U copyProperties(T source, U destination) {
+        // source 또는 destination이 null일 경우 null을 반환
+        if (source == null || destination == null) {
+            return null;
+        }
+
+        // BeanWrapper를 사용하여 source와 destination의 프로퍼티에 접근
+        final BeanWrapper src = new BeanWrapperImpl(source);
+        final BeanWrapper dest = new BeanWrapperImpl(destination);
+
+        // source 객체의 모든 필드를 순회하며 복사
+        for (Field property : source.getClass().getDeclaredFields()) {
+            // 필드에 접근할 수 있도록 설정 (private, protected 등 포함)
+            property.setAccessible(true);
+
+            // source 필드의 값을 가져옴
+            Object sourceProperty = src.getPropertyValue(property.getName());
+
+            // source의 값이 null이 아니고, 컬렉션 타입이 아닌 경우에만 복사
+            if (sourceProperty != null && !(sourceProperty instanceof Collection<?>)) {
+                // destination의 필드 타입과 일치하는지 체크
+                if (dest.isWritableProperty(property.getName())) {
+                    dest.setPropertyValue(property.getName(), sourceProperty);
+                }
+            }
+        }
+
+        return destination;
+    }
+}


### PR DESCRIPTION
close #86 

1. CustomBeanUtils 기능을 만들어 객체 간 복사할 때 set을 반복하는 방식이 아닌 null이 아닌 필드만 복사하도록 함.
- Payment, Review, CartItem이 해당됨.
- CustomBeanUtils에서 타입이 다르더라도 같은 필드만 복사하도록 하여 그에 맞게 도메인 필드명도 같게 함.

2. 프론트엔드에서 필드명을 알맞게하여 올바르게 렌더링이 되도록 하였으며, payment에서 그대로 렌더링이 되면서 id간 날짜가 다르더라도 그대로 렌더링되던점 수정 (날짜순 정렬하며, 같다면 id순 정렬)