### PR TITLE
SecurityConfig 설정 완료

### DIFF
--- a/AutumnShop/front/Autumnshop/components/cartItem/Payment.js
+++ b/AutumnShop/front/Autumnshop/components/cartItem/Payment.js
@@ -67,6 +67,7 @@ const Payment = ({ cartId, quantity, totalPrice }) => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${loginInfo.accessToken}`,
         },
         body: JSON.stringify({
           memberId: loginInfo.memberId,

--- a/AutumnShop/front/Autumnshop/components/product/Carts.js
+++ b/AutumnShop/front/Autumnshop/components/product/Carts.js
@@ -12,6 +12,7 @@ const Carts = ({ title, price, id, description, classes }) => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${loginInfo.accessToken}`,
         },
         body: JSON.stringify({
           memberId: loginInfo.memberId,

--- a/AutumnShop/front/Autumnshop/pages/mypage/myWrite.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/myWrite.js
@@ -154,12 +154,15 @@ const MyWriteForm = () => {
     };
 
     try {
+      const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+      
       const response = await fetch(
         "http://localhost:8080/members/write",
         {
           method: "PATCH",
           headers: {
             "Content-type": "application/json",
+            Authorization: `Bearer ${loginInfo.accessToken}`,            
           },
           body: JSON.stringify(memberSignupDto),
         }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Member/controller/MemberController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Member/controller/MemberController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -53,10 +54,16 @@ public class MemberController {
 
     // 정보 수정
     @PatchMapping("/write")
-    public ResponseEntity<MemberSignupResponseDto> updateMember(@RequestBody @Valid MemberUpdateDto memberUpdateDto, BindingResult bindingResult) {
+    public ResponseEntity<MemberSignupResponseDto> updateMember(@IfLogin LoginUserDto loginUserDto, @RequestBody @Valid MemberUpdateDto memberUpdateDto, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return new ResponseEntity<MemberSignupResponseDto>(HttpStatus.BAD_REQUEST);
         }
+
+        // 만약 로그인한 사용자와 수정하고자 하는 정보의 이메일 이 같지 않을 경우 리턴
+        if(!Objects.equals(loginUserDto.getEmail(), memberUpdateDto.getEmail())){
+            return new ResponseEntity<MemberSignupResponseDto>(HttpStatus.BAD_REQUEST);
+        }
+
         // 회원 정보 수정
         Member updatedMember = memberService.updateMember(memberUpdateDto);
 

--- a/AutumnShop/src/main/java/com/example/AutumnMall/config/SecurityConfig.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/config/SecurityConfig.java
@@ -36,15 +36,23 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .authorizeRequests(authorizeRequests -> {
                     authorizeRequests
-                            .antMatchers("/members/signup", "/members/login", "/members/refreshToken", "/carts", "/cartItems", "/payments", "/orders", "/payment/order").permitAll()
+                            .antMatchers(
+                                    "/members/signup", "/members/login", "/members/refreshToken"
+                            ).permitAll()
+
+                            // 접속 안 해도 볼 수 있음
                             .antMatchers(HttpMethod.GET, "/categories/**", "/products/**").permitAll()
-                            .antMatchers(HttpMethod.POST, "/payments/**").permitAll()
+
+                            // 최소 '유저' ~ '관리자'가 가능함
                             .antMatchers(HttpMethod.GET, "/**").hasAnyRole("USER")
                             .antMatchers(HttpMethod.POST, "/**").hasAnyRole("USER", "ADMIN")
-                            .antMatchers(HttpMethod.DELETE, "/cartItems/**").hasAnyRole("USER","ADMIN")
-                            .antMatchers(HttpMethod.DELETE, "/favorites/**").hasAnyRole("USER", "ADMIN");
+                            .antMatchers(HttpMethod.PATCH, "/carItems/**", "/members/**").hasAnyRole("USER", "ADMIN")
+                            .antMatchers(HttpMethod.DELETE, "/cartItems/**", "/favorites/**").hasAnyRole("USER","ADMIN")
 
-
+                            // 관리자만 가능
+                            .antMatchers(HttpMethod.POST, "/categories/**", "/products/**").hasRole("ADMIN")
+                            .antMatchers(HttpMethod.DELETE, "/payment/**", "/orders/**", "/products/**", "/categories", "/mileage", "members").hasRole("ADMIN")
+                            .antMatchers(HttpMethod.PATCH, "/payment/**", "/orders/**", "/products/**", "/categories", "/mileage").hasRole("ADMIN");
                 })
                 .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(customAuthenticationEntryPoint))
                 .apply(authenticationManagerConfig);


### PR DESCRIPTION
SecurityConfig를 수정하여 각 도메인의 메소드를 수정하여 올바르게 설정함.
예시:
관리자
1. 물건, 주문, 카테고리, 마일리지, 멤버 삭제는 관리자만 가능
2. 물건, 주문, 카테고리, 마일리지 변경 = 관리자만 가능
3. 물건, 카테고리 추가는 관리자만 가능

그 외 정보 수정 시 로그인한 사용자와 수정하고자 하는 정보의 이메일이 같지 않을 경우 리턴하도록 함. 보안 설정을 하면서 기존에 보안 체크를 제대로 하지 않았던 점 수정