### PR TITLE
기능을 작성하고 테스트 할 때 테스트 코드를 작성하고 restdoc로 문서화하도록 함

### DIFF
--- a/AutumnShop/build.gradle
+++ b/AutumnShop/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.9-SNAPSHOT'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'org.asciidoctor.jvm.convert' version '3.3.0'  // Asciidoctor 플러그인 적용
 }
 
 group = 'com.meet42'
@@ -18,6 +19,7 @@ repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' }
     maven { url 'https://repo.spring.io/snapshot' }
+    gradlePluginPortal()  // 플러그인 포털 추가
 }
 
 dependencies {
@@ -49,6 +51,11 @@ dependencies {
     compileOnly 'org.mapstruct:mapstruct-processor:1.5.3.Final' // MapStruct Processor 의존성 추가 (빌드 시 코드 생성용)
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final' // Annotation Processor 의존성 추가
 
+    // test
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
 tasks.withType(JavaCompile) {
@@ -58,4 +65,25 @@ tasks.withType(JavaCompile) {
 
 tasks.named('test') {
     useJUnitPlatform()
+    outputs.dir file('build/generated-snippets')  // 스니펫 디렉토리 경로 지정
+}
+
+test {
+    useJUnitPlatform() // JUnit 5 사용 시 필요
+    outputs.dir file('build/generated-snippets')  // Spring REST Docs 스니펫 디렉토리 설정
+}
+
+asciidoctor {
+    sourceDir = file('src/docs/asciidoc')  // Asciidoc 소스 디렉토리 설정
+    outputDir = file('build/docs/asciidoc')  // 최종 문서화된 파일이 저장될 디렉토리
+}
+
+task generateApiDocs {
+    dependsOn test
+    doLast {
+        // REST Docs 스니펫을 Asciidoc 형식으로 변환
+        exec {
+            commandLine 'gradle', 'asciidoctor'
+        }
+    }
 }

--- a/AutumnShop/front/Autumnshop/components/Untitled-1.ini
+++ b/AutumnShop/front/Autumnshop/components/Untitled-1.ini
@@ -3396,7 +3396,7 @@ public class RoleInitializer {
 
 
 토토
-package com.example.fakeshopapi.domain;
+package com.example.AutumnMall.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -3462,7 +3462,7 @@ Please write in academic writing style, Korean language.
 
 java
 Copy code
-package com.example.fakeshopapi.domain;
+package com.example.AutumnMall.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -3541,7 +3541,7 @@ public class Member {
 
 
 토토
-package com.example.fakeshopapi.dto;
+package com.example.AutumnMall.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -3580,7 +3580,7 @@ Please write in academic writing style, Korean language.
 
 java
 Copy code
-package com.example.fakeshopapi.dto;
+package com.example.AutumnMall.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -3634,7 +3634,7 @@ public class MemberSignupDto {
 
 
 토토
-package com.example.fakeshopapi.dto;
+package com.example.AutumnMall.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -6608,7 +6608,7 @@ return {
 
 위의 Rest API는 
 
-package com.example.fakeshopapi.domain;
+package com.example.AutumnMall.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;

--- a/AutumnShop/settings.gradle
+++ b/AutumnShop/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
         maven { url 'https://repo.spring.io/milestone' }
         maven { url 'https://repo.spring.io/snapshot' }
         gradlePluginPortal()
+        mavenCentral()
     }
 }
 rootProject.name = 'AutumnMall'

--- a/AutumnShop/src/test/java/com/example/AutumnMall/AutumnMallApplicationTests.java
+++ b/AutumnShop/src/test/java/com/example/AutumnMall/AutumnMallApplicationTests.java
@@ -1,4 +1,4 @@
-package com.example.fakeshopapi;
+package com.example.AutumnMall;
 /*
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/AutumnShop/src/test/java/com/example/AutumnMall/Cart/controller/CartItemControllerTest.java
+++ b/AutumnShop/src/test/java/com/example/AutumnMall/Cart/controller/CartItemControllerTest.java
@@ -1,0 +1,213 @@
+package com.example.AutumnMall.Cart.controller;
+
+import com.example.AutumnMall.Cart.dto.AddCartItemDto;
+import com.example.AutumnMall.Cart.domain.CartItem;
+import com.example.AutumnMall.Cart.dto.ResponseGetCartItemDto;
+import com.example.AutumnMall.Cart.service.CartItemService;
+import com.example.AutumnMall.exception.BusinessLogicException;
+import com.example.AutumnMall.exception.ExceptionCode;
+import com.example.AutumnMall.security.jwt.util.LoginUserDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
+@AutoConfigureRestDocs
+public class CartItemControllerTest {
+
+    @Mock
+    private CartItemService cartItemService;
+
+    @InjectMocks
+    private CartItemController cartItemController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup(RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.standaloneSetup(cartItemController)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentationContextProvider))
+                .build();
+
+    }
+
+    @Test
+    public void testAddCartItem_Success() throws Exception {
+        // 준비: AddCartItemDto와 CartItem 객체 설정
+        AddCartItemDto addCartItemDto = new AddCartItemDto();
+        addCartItemDto.setCartId(1L);
+        addCartItemDto.setProductId(1L);
+        addCartItemDto.setQuantity(2);
+
+        CartItem cartItem = new CartItem();
+        cartItem.setId(1L);
+        cartItem.setQuantity(2);
+
+        // Mocking: cartItemService.addCartItem 메서드 호출시 CartItem 반환하도록 설정
+        when(cartItemService.addCartItem(any(AddCartItemDto.class))).thenReturn(cartItem);
+
+        // 테스트: addCartItem 엔드포인트 호출
+        mockMvc.perform(post("/cartItems")
+                        .contentType("application/json")
+                        .content("{ \"cartId\": 1, \"productId\": 1, \"quantity\": 2 }"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.quantity").value(2))
+                .andDo(document("add-cart-item-success"));
+
+        // 검증: 서비스 메서드가 한 번 호출되었는지 확인
+        verify(cartItemService, times(1)).addCartItem(any(AddCartItemDto.class));
+    }
+
+    @Test
+    public void testAddCartItem_CartNotFound() throws Exception {
+        // 준비: AddCartItemDto 객체 설정
+        AddCartItemDto addCartItemDto = new AddCartItemDto();
+        addCartItemDto.setCartId(1L);
+        addCartItemDto.setProductId(1L);
+        addCartItemDto.setQuantity(2);
+
+        // Mocking: cartItemService.addCartItem 메서드가 BusinessLogicException을 던지도록 설정
+        when(cartItemService.addCartItem(any(AddCartItemDto.class)))
+                .thenThrow(new BusinessLogicException(ExceptionCode.CART_NOT_FOUND));
+
+        // 테스트: addCartItem 엔드포인트 호출
+        mockMvc.perform(post("/cartItems")
+                        .contentType("application/json")
+                        .content("{ \"cartId\": 1, \"productId\": 1, \"quantity\": 2 }"))
+                .andExpect(status().isBadRequest());
+
+        // 검증: 서비스 메서드가 한 번 호출되었는지 확인
+        verify(cartItemService, times(1)).addCartItem(any(AddCartItemDto.class));
+    }
+
+    @Test
+    public void testGetCartItems_Success() throws Exception {
+        // 준비: 로그인 유저와 cartId 설정
+        LoginUserDto loginUserDto = new LoginUserDto();
+        loginUserDto.setMemberId(1L);
+        Long cartId = 1L;
+
+        // ResponseGetCartItemDto 준비
+        ResponseGetCartItemDto cartItemDto = new ResponseGetCartItemDto();
+        cartItemDto.setId(1L);
+        cartItemDto.setProductId(1L);
+        cartItemDto.setTitle("Sample Product");
+        cartItemDto.setPrice(100.0);
+        cartItemDto.setDescription("This is a sample product.");
+        cartItemDto.setImageUrl("http://example.com/sample-product.jpg");
+        cartItemDto.setQuantity(2);
+
+        List<ResponseGetCartItemDto> cartItems = List.of(cartItemDto);
+
+        // Mocking: cartItemService.getCartItems 메서드 호출 시 cartItems 반환하도록 설정
+        when(cartItemService.getCartItems(loginUserDto.getMemberId(), cartId)).thenReturn(cartItems);
+
+        // 테스트: getCartItems 엔드포인트 호출
+        mockMvc.perform(get("/cartItems")
+                        .contentType("application/json")
+                        .param("cartId", String.valueOf(cartId))
+                        .param("memberId", String.valueOf(loginUserDto.getMemberId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].productId").value(1L))
+                .andExpect(jsonPath("$[0].title").value("Sample Product"))
+                .andExpect(jsonPath("$[0].price").value(100.0))
+                .andExpect(jsonPath("$[0].description").value("This is a sample product."))
+                .andExpect(jsonPath("$[0].imageUrl").value("http://example.com/sample-product.jpg"))
+                .andExpect(jsonPath("$[0].quantity").value(2))
+                .andDo(document("get-cart-items-success"));
+
+        // 검증: 서비스 메서드가 한 번 호출되었는지 확인
+        verify(cartItemService, times(1)).getCartItems(loginUserDto.getMemberId(), cartId);
+    }
+
+
+    @Test
+    public void testGetCartItems_CartNotFound() throws Exception {
+        // 준비: 로그인 유저와 cartId 설정
+        LoginUserDto loginUserDto = new LoginUserDto();
+        loginUserDto.setMemberId(1L);
+
+        // Mocking: cartItemService.getCartItems 메서드가 BusinessLogicException을 던지도록 설정
+        when(cartItemService.getCartItems(any(Long.class), any(Long.class)))
+                .thenThrow(new BusinessLogicException(ExceptionCode.CART_NOT_FOUND));
+
+        // 테스트: getCartItems 엔드포인트 호출
+        mockMvc.perform(get("/cartItems")
+                        .contentType("application/json")
+                        .param("cartId", "1")
+                        .param("memberId", String.valueOf(loginUserDto.getMemberId())))
+                .andExpect(status().isBadRequest()) // HTTP 상태 코드 400 (Bad Request) 기대
+                .andExpect(jsonPath("$.message").value("Cart not found")) // 예외 메시지 확인
+                .andDo(document("get-cart-items-cart-not-found"));
+
+        // 검증: 서비스 메서드가 한 번 호출되었는지 확인
+        verify(cartItemService, times(1)).getCartItems(any(Long.class), any(Long.class));
+    }
+
+
+    @Test
+    public void testDeleteCartItem_Success() throws Exception {
+        // 준비: 로그인 유저 설정 및 cartItemId
+        LoginUserDto loginUserDto = new LoginUserDto();
+        loginUserDto.setMemberId(1L);
+        Long cartItemId = 1L;
+
+        // Mocking: cartItemService.isCartItemExist 메서드가 true 반환하도록 설정
+        when(cartItemService.isCartItemExist(cartItemId, loginUserDto.getMemberId())).thenReturn(true);
+
+        // 테스트: deleteCartItem 엔드포인트 호출
+        mockMvc.perform(delete("/cartItems/{cartItemId}", cartItemId)
+                        .contentType("application/json")
+                        .param("memberId", String.valueOf(loginUserDto.getMemberId()))
+                        .param("cartItemId", String.valueOf(cartItemId)))
+                .andExpect(status().isOk()) // 정상적으로 처리되면 200 OK 상태 코드
+                .andDo(document("delete-cart-item-success"));
+
+        // 검증: 서비스 메서드가 한 번 호출되었는지 확인
+        verify(cartItemService, times(1)).deleteCartItem(cartItemId);
+    }
+
+    @Test
+    public void testDeleteCartItem_CartItemNotFound() throws Exception {
+        // 준비: 로그인 유저 설정 및 cartItemId
+        LoginUserDto loginUserDto = new LoginUserDto();
+        loginUserDto.setMemberId(1L);
+        Long cartItemId = 1L;
+
+        // Mocking: cartItemService.isCartItemExist 메서드가 false 반환하도록 설정
+        when(cartItemService.isCartItemExist(cartItemId, loginUserDto.getMemberId())).thenReturn(false);
+
+        // 테스트: deleteCartItem 엔드포인트 호출
+        mockMvc.perform(delete("/cartItems/{cartItemId}", cartItemId)
+                        .contentType("application/json")
+                        .param("memberId", String.valueOf(loginUserDto.getMemberId()))
+                        .param("cartItemId", String.valueOf(cartItemId)))
+                .andExpect(status().isBadRequest()) // 장바구니 아이템이 없을 경우 400 Bad Request
+                .andExpect(jsonPath("$.message").value("Cart item not found")) // 예외 메시지 검증
+                .andDo(document("delete-cart-item-cart-item-not-found"));
+
+        // 검증: 서비스 메서드가 호출되지 않았는지 확인
+        verify(cartItemService, times(0)).deleteCartItem(cartItemId);
+    }
+}

--- a/AutumnShop/src/test/java/com/example/AutumnMall/util/JwtTokenizerTest.java
+++ b/AutumnShop/src/test/java/com/example/AutumnMall/util/JwtTokenizerTest.java
@@ -1,4 +1,4 @@
-package com.example.fakeshopapi.util;
+package com.example.AutumnMall.util;
 
 import com.example.AutumnMall.security.jwt.util.JwtTokenizer;
 import io.jsonwebtoken.Claims;


### PR DESCRIPTION
close #102 

cartItem을 예시로 테스트 코드를 작성하고 API 문서화 정보를 저장할 수 잇도록 함.

1. 구현할 API의 동작을 테스트하는 클래스를 작성함
2. @WebMvcTest와 @AutoConfigureRestDocs를 사용하여, 테스트하면서 자동으로 문서화가 이루어지도록 함.
3. 테스트를 실행하면 target/snippets 디렉토리에 API 문서화 정보가 생성됨