### PR TITLE
CartItem에서 cartItem을 추가할 때, 여러 데이터가 오는 것을 위해 Spring JPA Batch 설정 완료

### DIFF
--- a/AutumnShop/front/Autumnshop/components/product/Carts.js
+++ b/AutumnShop/front/Autumnshop/components/product/Carts.js
@@ -2,6 +2,8 @@ import React from "react";
 import { Button } from "@mui/material";
 
 const Carts = ({ title, price, id, description, classes }) => {
+  const isBatchRequest = false;
+
   const handleSubmit = async (event) => {
     event.preventDefault();
   
@@ -26,15 +28,16 @@ const Carts = ({ title, price, id, description, classes }) => {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${loginInfo.accessToken}`,
+          "Batch-Request": isBatchRequest ? "true" : "false", // 배치 요청인지 아닌지 판단
         },
-        body: JSON.stringify({
+        body: JSON.stringify([{
           cartId: cartData.id,
           productId: id,
           productTitle: title,
           productPrice: price,
           productDescription: description,
           quantity: 1,
-        }),
+        }]),
       });
       
       if (itemsResponse.ok) {

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/service/CartItemService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/service/CartItemService.java
@@ -276,4 +276,24 @@ public class CartItemService {
         }
     }
 
+
+    /// 배치 처리
+    @Transactional
+    public void addItemsToCart(List<AddCartItemDto> addCartItemDtos) {
+        // 상품 ID와 수량 추출
+        List<Long> productIds = addCartItemDtos.stream()
+                .map(AddCartItemDto::getProductId)
+                .collect(Collectors.toList());
+        List<Integer> quantities = addCartItemDtos.stream()
+                .map(AddCartItemDto::getQuantity)
+                .collect(Collectors.toList());
+
+        List<Long> cartIds = addCartItemDtos.stream()
+                .map(AddCartItemDto::getCartId)
+                .collect(Collectors.toList());
+
+        // 벌크 업데이트 호출
+        cartItemRepository.bulkUpdateCartItemQuantities(cartIds, productIds, quantities);
+    }
+
 }

--- a/AutumnShop/src/main/resources/application.yml
+++ b/AutumnShop/src/main/resources/application.yml
@@ -24,3 +24,6 @@ spring:
         show_sql: true
         format_sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
+  batch:
+    job:
+      enabled: false

--- a/AutumnShop/src/test/java/com/example/AutumnMall/CartItem/Batch/CartItemServiceBatchTest.java
+++ b/AutumnShop/src/test/java/com/example/AutumnMall/CartItem/Batch/CartItemServiceBatchTest.java
@@ -1,0 +1,117 @@
+package com.example.AutumnMall.CartItem.Batch;
+
+import com.example.AutumnMall.Cart.controller.CartItemController;
+import com.example.AutumnMall.Cart.dto.AddCartItemDto;
+import com.example.AutumnMall.Cart.service.CartItemService;
+import com.example.AutumnMall.security.jwt.util.LoginUserDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
+@AutoConfigureRestDocs
+public class CartItemServiceBatchTest {
+
+    @Mock
+    private CartItemService cartItemService;
+
+    @InjectMocks
+    private CartItemController cartItemController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup(RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.standaloneSetup(cartItemController)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentationContextProvider))
+                .build();
+
+    }
+
+    @Test
+    public void testBulkUpdate_Success() throws Exception {
+        Long cartId = 1L;
+        Long memberId = 1L; // 로그인된 사용자의 memberId
+        List<AddCartItemDto> addCartItemDtos = new ArrayList<>();
+
+        // 테스트 데이터 생성
+        for (long i = 1; i <= 100000; i++) {
+            AddCartItemDto dto = new AddCartItemDto();
+            dto.setCartId(i);
+            dto.setProductId(1L);
+            dto.setQuantity(2);
+            addCartItemDtos.add(dto);
+        }
+
+        // LoginUserDto 설정
+        LoginUserDto loginUserDto = new LoginUserDto();
+        loginUserDto.setMemberId(memberId);
+
+        // CartItemService의 addItemsToCart 메서드 mocking
+        doNothing().when(cartItemService).addItemsToCart(addCartItemDtos);
+
+        // 테스트: 배치 요청이므로 Batch-Request 헤더를 true로 설정
+        mockMvc.perform(post("/cartItems")
+                        .param("memberId", String.valueOf(loginUserDto.getMemberId()))
+                        .header("Batch-Request", "true") // Batch-Request 헤더 설정
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(addCartItemDtos)))
+                .andExpect(status().isOk())
+                .andDo(document("cart-item-update-bulk-success"));
+
+        // 검증: 서비스의 addItemsToCart 메서드가 호출되었는지 확인
+        verify(cartItemService, times(1)).addItemsToCart(addCartItemDtos);
+    }
+
+    @Test
+    public void testBulkUpdate_Fail() throws Exception {
+        List<AddCartItemDto> addCartItemDtos = new ArrayList<>();
+        Long memberId = 1L;
+
+        // 잘못된 데이터 (예: cartId가 null)
+        AddCartItemDto dto = new AddCartItemDto();
+        dto.setCartId(null); // 잘못된 cartId
+        dto.setProductId(1L);
+        dto.setQuantity(2);
+        addCartItemDtos.add(dto);
+
+        LoginUserDto loginUserDto = new LoginUserDto();
+        loginUserDto.setMemberId(memberId);
+
+        // CartItemService가 예외를 던지도록 설정
+        doThrow(new IllegalArgumentException("Cart ID cannot be null"))
+                .when(cartItemService).addItemsToCart(addCartItemDtos);
+
+        // 요청 수행 및 예외 검증
+        mockMvc.perform(post("/cartItems")
+                        .param("memberId", String.valueOf(loginUserDto.getMemberId()))
+                        .header("Batch-Request", "true")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(addCartItemDtos)))
+                .andExpect(status().isBadRequest()) // 400 상태 코드 확인
+                .andDo(document("cart-item-update-bulk-fail"));
+
+        // 검증: 예외가 발생했는지 확인
+        verify(cartItemService, times(1)).addItemsToCart(addCartItemDtos);
+    }
+}

--- a/AutumnShop/src/test/java/com/example/AutumnMall/CartItem/service/CartItemServiceTest.java
+++ b/AutumnShop/src/test/java/com/example/AutumnMall/CartItem/service/CartItemServiceTest.java
@@ -1,5 +1,6 @@
-package com.example.AutumnMall.Cart.controller;
+package com.example.AutumnMall.CartItem.service;
 
+import com.example.AutumnMall.Cart.controller.CartItemController;
 import com.example.AutumnMall.Cart.dto.AddCartItemDto;
 import com.example.AutumnMall.Cart.domain.CartItem;
 import com.example.AutumnMall.Cart.dto.ResponseGetCartItemDto;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
 @AutoConfigureRestDocs
-public class CartItemControllerTest {
+public class CartItemServiceTest {
 
     @Mock
     private CartItemService cartItemService;


### PR DESCRIPTION
close #104 

벌크 업데이트 (@Modifying Query) 방식을 사용하여  saveAll보다  성능을 크게 향상시킴 대량 데이터 트랜잭션 처리를 위한 Batch 서비스 추가 및 테스트 완료
(addCartItem 컨트롤러만 적용)
addCartItem이 배치 처리를 위해 List형식으로 받기 때문에 프론트엔드 수정