### PR TITLE
 cartItem의 delete (30일이 지났을 경우)  작업에 대해 테스트 코드를 작성

### DIFF
--- a/AutumnShop/src/main/java/com/example/AutumnMall/batch/config/BatchConfig.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/batch/config/BatchConfig.java
@@ -46,16 +46,16 @@ public class BatchConfig {
                 .processor(oldCartItemProcessor())
                 .writer(oldCartItemWriter())
                 .faultTolerant() // 오류 발생 시 fault tolerance 적용
-                .retry(NullPointerException.class) // Retry NullPointerException
-                .retryLimit(5)
-                .skip(NullPointerException.class)  // Skip NullPointerException
-                .skipLimit(10)  // 최대 10번까지 Skip 가능
+                .retry(Exception.class) // Retry NullPointerException
+                .retryLimit(3)
+                .skip(Exception.class)  // Skip NullPointerException
+                .skipLimit(5)  // 최대 10번까지 Skip 가능
                 .listener(new CartItemBatchListener()) // 배치 리스너
                 .build();
     }
 
     // OldCartItemReader와 OldCartItemWriter 빈으로 설정
-    @Bean("customOldCartItemReader")
+    @Bean
     public OldCartItemReader oldCartItemReader() {
         return new OldCartItemReader(cartItemJdbcRepository); // OldCartItemReader 클래스 정의
     }
@@ -67,6 +67,6 @@ public class BatchConfig {
 
     @Bean
     public OldCartItemProcessor oldCartItemProcessor(){
-        return new OldCartItemProcessor(cartItemJdbcRepository);
+        return new OldCartItemProcessor();
     }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/batch/processor/OldCartItemProcessor.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/batch/processor/OldCartItemProcessor.java
@@ -18,13 +18,7 @@ import org.springframework.batch.core.StepExecution;
 @Setter
 public class OldCartItemProcessor implements ItemProcessor<CartItem, CartItem>, StepExecutionListener {
 
-    private final CartItemJdbcRepository cartItemJdbcRepository;
     private JobParameters jobParameters;
-
-    public OldCartItemProcessor(CartItemJdbcRepository cartItemJdbcRepository) {
-        this.cartItemJdbcRepository = cartItemJdbcRepository;
-    }
-
 
     @Override
     public void beforeStep(StepExecution stepExecution) {
@@ -36,7 +30,6 @@ public class OldCartItemProcessor implements ItemProcessor<CartItem, CartItem>, 
     public ExitStatus afterStep(StepExecution stepExecution) {
         // 예외가 발생했을 경우 실패로 처리
         if (stepExecution.getFailureExceptions().size() > 0) {
-            System.out.println(1);
             return ExitStatus.FAILED;
         }
         return ExitStatus.COMPLETED;
@@ -44,9 +37,15 @@ public class OldCartItemProcessor implements ItemProcessor<CartItem, CartItem>, 
 
     @Override
     public CartItem process(CartItem cartItem) throws Exception {
-        Long id = jobParameters.getLong("id");
+        if (jobParameters != null) {
+            Long id = jobParameters.getLong("id");
 
-        if(id == -100){
+            if (id <= -1) {
+                throw new BusinessLogicException(ExceptionCode.CARTITEM_NOT_FOUND);
+            }
+        }
+
+        if(cartItem == null){
             throw new BusinessLogicException(ExceptionCode.CARTITEM_NOT_FOUND);
         }
 
@@ -54,6 +53,7 @@ public class OldCartItemProcessor implements ItemProcessor<CartItem, CartItem>, 
         if (cartItem.getQuantity() == 0) {
             throw new BusinessLogicException(ExceptionCode.CARTITEM_NOT_FOUND);
         }
+
         return cartItem;
     }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/batch/reader/OldCartItemReader.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/batch/reader/OldCartItemReader.java
@@ -2,6 +2,7 @@ package com.example.AutumnMall.batch.reader;
 
 import com.example.AutumnMall.Cart.domain.CartItem;
 import com.example.AutumnMall.Cart.repository.CartItemJdbcRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -10,6 +11,7 @@ import javax.annotation.PostConstruct;
 import java.util.Iterator;
 import java.util.List;
 
+@Slf4j
 public class OldCartItemReader implements ItemReader<CartItem> {
 
     private final CartItemJdbcRepository cartItemJdbcRepository;
@@ -29,6 +31,25 @@ public class OldCartItemReader implements ItemReader<CartItem> {
 
     @Override
     public CartItem read() throws Exception {
+        // Iterator가 없거나 더 이상 요소가 없을 때, 새롭게 데이터를 불러옴
+        if (cartItemIterator == null || !cartItemIterator.hasNext()) {
+            List<CartItem> oldCartItems = cartItemJdbcRepository.findCartItemsOlderThan(30);
+            if (oldCartItems.isEmpty()) {
+                log.info("삭제할 장바구니 아이템이 없습니다.");
+                throw new Exception("삭제할 장바구니 아이템이 없음");
+            }
+            cartItemIterator = oldCartItems.iterator();
+        }
+
+        if (cartItemIterator.hasNext()) {
+            CartItem cartItem = cartItemIterator.next();
+            if (cartItem == null || cartItem.getQuantity() <= 0) {
+                log.warn("잘못된 CartItem 발견: {}", cartItem);
+                return null; // 예외를 던지지 않고 null 반환
+            }
+            return cartItem;
+        }
+
         return cartItemIterator.hasNext() ? cartItemIterator.next() : null;
     }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/batch/scheduler/BatchScheduler.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/batch/scheduler/BatchScheduler.java
@@ -1,12 +1,13 @@
 package com.example.AutumnMall.batch.scheduler;
 
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.*;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.Date;
 
 @Configuration
 @EnableScheduling
@@ -27,6 +28,15 @@ public class BatchScheduler {
     // 매일 자정에 배치 작업 실행 (0 0 0 * * *)
     @Scheduled(cron = "0 0 0 * * *")
     public void executeBatchJob() throws Exception {
-        jobLauncher.run(cartItemBatchJob, new JobParameters());
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addDate("timestamp", new Date()) // 실행할 때마다 새로운 파라미터 추가
+                    .toJobParameters();
+
+            JobExecution execution = jobLauncher.run(cartItemBatchJob, jobParameters);
+            System.out.println("Batch job 실행 상태: " + execution.getStatus());
+        } catch (JobExecutionException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/AutumnShop/src/test/java/com/example/AutumnMall/CartItem/Batch/CartItemBatchTest.java
+++ b/AutumnShop/src/test/java/com/example/AutumnMall/CartItem/Batch/CartItemBatchTest.java
@@ -28,6 +28,10 @@ public class CartItemBatchTest {
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
 
+    @Autowired
+    private Job cartItemBatchJob;
+
+    //밑의 장바구니를 기준으로 배치 테스트 완료했으니, 해당 테스트는 필요없습니다. ( 장바구니 추가 테스트와 같음 )
     @Test
     void 배치_정상_실행_테스트() throws Exception {
         // Given
@@ -78,4 +82,40 @@ public class CartItemBatchTest {
         assertThat(logContent).contains("배치 작업 시작"); // 로그 내용 확인
 
     }
+
+    @Test
+    void 장바구니_30일_지난_아이템_삭제_테스트() throws Exception {
+        assertThat(cartItemBatchJob).isNotNull();
+        assertThat(jobLauncherTestUtils.getJobLauncher()).isNotNull();
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("time", System.currentTimeMillis()) // 각 실행마다 새로운 파라미터
+                .addLong("id", 1L)
+                .toJobParameters();
+
+        // When
+        JobExecution jobExecution = jobLauncherTestUtils.getJobLauncher().run(cartItemBatchJob, jobParameters);
+
+        // Then
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+    }
+
+    @Test
+    void 장바구니_30일_지난_아이템_삭제_실패_테스트() throws Exception {
+        assertThat(cartItemBatchJob).isNotNull();
+        assertThat(jobLauncherTestUtils.getJobLauncher()).isNotNull();
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("time", System.currentTimeMillis()) // 각 실행마다 새로운 파라미터
+                .addLong("id", 1L)
+                .toJobParameters();
+
+        // When
+        JobExecution jobExecution = jobLauncherTestUtils.getJobLauncher().run(cartItemBatchJob, jobParameters);
+
+        // Then: 배치 작업이 실패했을 경우
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.FAILED);
+    }
+
+
 }


### PR DESCRIPTION
각각, 실패와 성공을 기준으로 함

1. OldCartItemReader에서 데이터 초기화 문제가 발생해 @PostConstruct에서 데이터를 불러오는 것이 아니라, read()를 호출할 때마다 최신 데이터를 가져오도록 변경.
2. JobParameters에서 id를 가져오는데, null일 경우 NPE 발생 가능하여 jobParameters.getLong("id")를 호출하기 전에 null 체크 추가.
+ 불필요한 cartItemJdbcRepository  의존성 제거
3. BatchConfig에서 reader() 호출 방식 변경 ( 일관되게 @Bean만 적용)
4. 매일 실행될 때마다 동일한 JobParameters를 사용하면 Spring Batch가 중복 실행을 방지하여 실행되지 않을 수 있어 실행할 때마다 고유한 파라미터를 추가.

+

cartItem 배치 테스트시 테스트와 같이 기본적으로 time과 id가 주어져야 합니다. time은 각 실행마다 새로운 파라미터를 부여해 독립성을 해치지 않기 위함입니다.
id는 processor에서 불일치하는 배치를 실행시키지 않기 위함입니다.