### PR TITLE
장바구니에서 30일 지난 장바구니 배치 기능을 프론트에 구현함

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/welcome.js
+++ b/AutumnShop/front/Autumnshop/pages/welcome.js
@@ -139,6 +139,27 @@ const MainPage = () => {
       });
     }
   };
+
+  const handleBatchDelete = async () => {
+    const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+    try {
+        const response = await fetch("http://localhost:8080/carts/batch/deleteOldCartItems", {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${loginInfo.accessToken}`,
+            },
+        });
+
+        console.log("응답 상태 코드:", response.status);
+        if (response.ok) {
+            alert("배치 작업이 성공적으로 완료됐습니다!")
+        } else {
+          alert('배치 작업에 실패했습니다.');
+        }
+    } catch (error) {
+        console.error('배치 작업 실행 중 오류 발생:', error);
+    }
+};
   
   return (
     <div className={classes.container}>
@@ -173,7 +194,14 @@ const MainPage = () => {
         <ProductSection title="신발" subtitle="인기 신발" products={shoesProducts} sectionRef={shoesRef} />
         <ProductSection title="악세서리" subtitle="인기 악세서리" products={accessoryProducts} sectionRef={accessoryRef} />
       </div>
+
+        <div>
+    <button onClick={handleBatchDelete} >
+      배치 작업 테스트
+    </button>
+  </div>
     </div>
+    
   );
 };
 

--- a/AutumnShop/src/main/java/com/example/AutumnMall/AutumnMallApplication.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/AutumnMallApplication.java
@@ -3,11 +3,13 @@ package com.example.AutumnMall;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 @SpringBootApplication
 @EnableGlobalMethodSecurity(prePostEnabled=true)
 @EnableJpaAuditing
+@EnableScheduling
 public class AutumnMallApplication {
 
     public static void main(String[] args) {

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/controller/CartApiController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/controller/CartApiController.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @RestController

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Cart/controller/CartItemBatchController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Cart/controller/CartItemBatchController.java
@@ -1,0 +1,31 @@
+package com.example.AutumnMall.Cart.controller;
+
+import com.example.AutumnMall.Cart.service.CartItemBatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/carts/batch")
+@RequiredArgsConstructor
+@Slf4j
+public class CartItemBatchController {
+
+    private final CartItemBatchService cartItemBatchService;
+
+    @PostMapping("/deleteOldCartItems")
+    public ResponseEntity<String> runCartItemBatch() {
+        System.out.println(1);
+        boolean success = cartItemBatchService.runCartItemBatch();
+        if (success) {
+            return ResponseEntity.ok("Batch job started successfully");
+        } else {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Failed to start batch job");
+        }
+    }
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/batch/config/BatchConfig.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/batch/config/BatchConfig.java
@@ -6,7 +6,6 @@ import com.example.AutumnMall.batch.listener.CartItemBatchListener;
 import com.example.AutumnMall.batch.processor.OldCartItemProcessor;
 import com.example.AutumnMall.batch.reader.OldCartItemReader;
 import com.example.AutumnMall.batch.writer.OldCartItemWriter;
-import com.example.AutumnMall.exception.BusinessLogicException;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;

--- a/AutumnShop/src/main/java/com/example/AutumnMall/batch/reader/OldCartItemReader.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/batch/reader/OldCartItemReader.java
@@ -36,7 +36,7 @@ public class OldCartItemReader implements ItemReader<CartItem> {
             List<CartItem> oldCartItems = cartItemJdbcRepository.findCartItemsOlderThan(30);
             if (oldCartItems.isEmpty()) {
                 log.info("삭제할 장바구니 아이템이 없습니다.");
-                throw new Exception("삭제할 장바구니 아이템이 없음");
+                return null;
             }
             cartItemIterator = oldCartItems.iterator();
         }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/batch/scheduler/BatchScheduler.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/batch/scheduler/BatchScheduler.java
@@ -1,5 +1,6 @@
 package com.example.AutumnMall.batch.scheduler;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.*;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.Date;
 
+@Slf4j
 @Configuration
 @EnableScheduling
 public class BatchScheduler {
@@ -31,12 +33,15 @@ public class BatchScheduler {
         try {
             JobParameters jobParameters = new JobParametersBuilder()
                     .addDate("timestamp", new Date()) // 실행할 때마다 새로운 파라미터 추가
+                    .addLong("id", 1L)
                     .toJobParameters();
 
             JobExecution execution = jobLauncher.run(cartItemBatchJob, jobParameters);
             System.out.println("Batch job 실행 상태: " + execution.getStatus());
         } catch (JobExecutionException e) {
-            e.printStackTrace();
+            log.error("자정에 배치 작업을 하는 데 실패했습니다");
+        } catch (Exception e){
+            log.error("배치 작업 실행 중 예외가 발생했습니다.");
         }
     }
 }

--- a/AutumnShop/src/main/resources/application-test.yml
+++ b/AutumnShop/src/main/resources/application-test.yml
@@ -27,7 +27,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
   batch:
     job:
-      enabled: false
+      enabled: true # 배치 작업 활성화
     initialize-schema: never
   main:
     allow-bean-definition-overriding: true

--- a/AutumnShop/src/main/resources/application.yml
+++ b/AutumnShop/src/main/resources/application.yml
@@ -31,3 +31,7 @@ spring:
     initialize-schema: never
   main:
     allow-bean-definition-overriding: true
+  task:
+    scheduling:
+      pool:
+        size: 10


### PR DESCRIPTION
1. 백에서 배치 기능을 위한 컨트롤러, 서비스 등을 구현함
2. 프론트에서 api를 호출하도록 하며, 특정 버튼을 통해 이루어지도록 함.
3. 장바구니 아이템을 찾을 때 존재하지 않을 경우 return null하여 상태를 Success로 리턴하여 끝냄
4. 만약, 장바구니 아이템이 없거나 장바구니 물건의 개수가 0인 것이 있을 경우 예외를 던져 상태가 FAILED가 됨

+

자정에 배치 작업을 실행하도록 size를 정했으며, 로그 추가  및 메인에 스케줄링 기능 활성화