### PR TITLE
포트원을 활용하여 장바구니 페이지에서 물품을 결제 시, 카카오페이 간편결제창이 뜨도록 함.

### DIFF
--- a/AutumnShop/.gitignore
+++ b/AutumnShop/.gitignore
@@ -39,3 +39,6 @@ out/
 # 로그 파일 제외
 logs/
 *.log
+
+# env 파일 제외
+.env*

--- a/AutumnShop/build.gradle
+++ b/AutumnShop/build.gradle
@@ -20,6 +20,12 @@ repositories {
     maven { url 'https://repo.spring.io/milestone' }
     maven { url 'https://repo.spring.io/snapshot' }
     gradlePluginPortal()  // 플러그인 포털 추가
+
+    allprojects {
+        repositories {
+            maven { url 'https://jitpack.io'}
+        }
+    }
 }
 
 dependencies {
@@ -47,6 +53,9 @@ dependencies {
     // dto validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // env 파일을 추가하여 깃허브에 올라가면 안 되는 민감한 정보 숨기기
+    implementation 'io.github.cdimascio:dotenv-java:3.2.0'
+
     // mapper
     implementation 'org.mapstruct:mapstruct:1.5.3.Final' // MapStruct 의존성 추가
     compileOnly 'org.mapstruct:mapstruct-processor:1.5.3.Final' // MapStruct Processor 의존성 추가 (빌드 시 코드 생성용)
@@ -67,6 +76,9 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // iamport (카카오톡, 토스, 네이버페이 같은 간편 결제)
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.21'
 }
 
 tasks.withType(JavaCompile) {

--- a/AutumnShop/front/Autumnshop/package-lock.json
+++ b/AutumnShop/front/Autumnshop/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.11.13",
         "@mui/styles": "^5.11.13",
         "axios": "^1.3.4",
+        "iamport-react-native": "^2.0.13",
         "next": "13.2.4",
         "react": "18.2.0",
         "react-cookie": "^4.1.1",
@@ -1291,6 +1292,17 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
+    "node_modules/iamport-react-native": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/iamport-react-native/-/iamport-react-native-2.0.13.tgz",
+      "integrity": "sha512-oibFtNg/CCQ8jpYxK3oh4RhEQyv5DpuIYnzfcEJ3ZpyObcKnJ5WXsaFGp2dzWQnxq7iJlN21yR5ii/1UPOb6aQ==",
+      "peerDependencies": {
+        "query-string": "8.x",
+        "react": "*",
+        "react-native": "*",
+        "react-native-webview": ">=11.x"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",

--- a/AutumnShop/front/Autumnshop/package.json
+++ b/AutumnShop/front/Autumnshop/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^5.11.13",
     "@mui/styles": "^5.11.13",
     "axios": "^1.3.4",
+    "iamport-react-native": "^2.0.13",
     "next": "13.2.4",
     "react": "18.2.0",
     "react-cookie": "^4.1.1",

--- a/AutumnShop/front/Autumnshop/pages/_app.js
+++ b/AutumnShop/front/Autumnshop/pages/_app.js
@@ -4,6 +4,7 @@ import { Box } from "@mui/material"; // Container 대신 Box 사용
 import AppBar from "../components/AppBar";
 import { createTheme } from "@mui/material/styles";
 import Router from "next/router";
+import Script from 'next/script';
 
 const theme = createTheme({
   typography: {
@@ -73,6 +74,10 @@ function MyApp({ Component, pageProps }) {
         }}
       >
 
+      <Script 
+        src="https://cdn.iamport.kr/v1/iamport.js" 
+        strategy="beforeInteractive"
+      />
         {/* Content Section */}
         <Box
           sx={{

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/controller/PaymentController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/controller/PaymentController.java
@@ -2,6 +2,8 @@ package com.example.AutumnMall.Payment.controller;
 
 import com.example.AutumnMall.Payment.domain.Payment;
 import com.example.AutumnMall.Payment.dto.AddPaymentDto;
+import com.example.AutumnMall.exception.BusinessLogicException;
+import com.example.AutumnMall.exception.ExceptionCode;
 import com.example.AutumnMall.security.jwt.util.IfLogin;
 import com.example.AutumnMall.security.jwt.util.LoginUserDto;
 import com.example.AutumnMall.Payment.service.PaymentService;
@@ -24,11 +26,10 @@ public class PaymentController {
                                                 @RequestBody AddPaymentDto addPaymentDto) {
         try {
             return ResponseEntity.ok(paymentService.addPayment(loginUserDto.getMemberId(),
-                    addPaymentDto.getCartId(), addPaymentDto.getOrderId(), addPaymentDto.getQuantity()));
+                    addPaymentDto.getCartId(), addPaymentDto.getOrderId(), addPaymentDto.getQuantity(), addPaymentDto.getImpuid()));
 
         }catch(Exception ex){
-            ex.printStackTrace();
-            return null;
+            throw new BusinessLogicException(ExceptionCode.PAYMENT_NOT_FOUND);
         }
     }
 

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Payment.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Payment.java
@@ -20,6 +20,10 @@ public class Payment extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name="impuid")
+    private String impuid;
+    private String status;
+
     private String imageUrl;
     private Long productId;
     private Double price;

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/dto/AddPaymentDto.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/dto/AddPaymentDto.java
@@ -9,4 +9,5 @@ public class AddPaymentDto {
     private Long cartId;
     private List<Integer> quantity;
     private Long orderId;
+    private String impuid;
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/dto/ResponsePaymentDto.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/dto/ResponsePaymentDto.java
@@ -1,0 +1,17 @@
+package com.example.AutumnMall.Payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ResponsePaymentDto {
+    private String impuid;
+    private String name;
+    private String status;
+    private Long amount;
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/repository/PaymentRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/repository/PaymentRepository.java
@@ -20,4 +20,5 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     boolean existsByMemberAndProductId(Member member, Long productId);
 
+    boolean existsByImpuid(String impuid);
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/exception/ExceptionCode.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/exception/ExceptionCode.java
@@ -12,9 +12,11 @@ public enum ExceptionCode {
     FAVORITES_NOT_FOUND(404, "즐겨찾기한 물품들을 찾을 수 없습니다"),
     ORDER_NOT_FOUND(500, "해당 주문 목록을 찾을 수 없습니다"),
     PAYMENT_NOT_FOUND(500, "해당 구매 목록을 찾을 수 없습니다"),
+    PAYMENT_ALREADY_PAID(400, "이미 처리된 결제입니다."),
+    IAMPORT_NOT_FOUND(404, "결제 기능을 찾을 수 없습니다"),
     REVIEW_NOT_FOUND(500, "해당 물품의 리뷰 목록을 찾을 수 없습니다"),
     INVALID_CARTITEM_STATUS(400, "구매 가능한 수량보다 더 구매할 수 없습니다! (최대 수량: 10)"),
-    INVALID_PAYMENT_STATUS(400, "구매 가능한 수량보다 더 구매할 수 없습니다!"),
+    INVALID_PAYMENT_STATUS(400, "유효하지 않은 결제입니다!"),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류");
 
 

--- a/AutumnShop/src/test/java/com/example/AutumnMall/Payment/service/PaymentServiceTest.java
+++ b/AutumnShop/src/test/java/com/example/AutumnMall/Payment/service/PaymentServiceTest.java
@@ -1,0 +1,99 @@
+package com.example.AutumnMall.Payment.service;
+
+import com.example.AutumnMall.Payment.controller.PaymentController;
+import com.example.AutumnMall.Payment.domain.Payment;
+import com.example.AutumnMall.Payment.dto.AddPaymentDto;
+import com.example.AutumnMall.Payment.service.PaymentService;
+import com.example.AutumnMall.security.jwt.util.LoginUserDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@ActiveProfiles("test")
+@Slf4j
+@SpringBatchTest
+@SpringBootTest
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
+@AutoConfigureRestDocs
+public class PaymentServiceTest {
+
+    @Mock
+    private PaymentService paymentService;
+
+    @InjectMocks
+    private PaymentController paymentController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup(RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.standaloneSetup(paymentController)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentationContextProvider))
+                .build();
+
+    }
+
+    @Test
+    public void testAddPayment_Success() throws Exception {
+        Long memberId = 1L;
+        Long cartId = 1L;
+        Long orderId = 1L;
+        String impuid = "imp53071323";
+        List<Integer> quantities = List.of(1, 2);
+
+        // AddPaymentDto 설정
+        AddPaymentDto addPaymentDto = new AddPaymentDto();
+        addPaymentDto.setCartId(cartId);
+        addPaymentDto.setOrderId(orderId);
+        addPaymentDto.setQuantity(quantities);
+        addPaymentDto.setImpuid(impuid);
+
+        // Payment 객체 설정
+        Payment payment = new Payment();
+        payment.setId(1L);
+        payment.setPrice((double) 100L);
+        payment.setImpuid("imp53071323");
+
+        // LoginUserDto 설정
+        LoginUserDto loginUserDto = new LoginUserDto();
+        loginUserDto.setMemberId(memberId);
+
+        // Mocking: paymentService.addPayment 메서드 호출 시 Payment 객체 반환
+        when(paymentService.addPayment(memberId, cartId, orderId, quantities, impuid))
+                .thenReturn(List.of(payment));
+
+        // 테스트: 결제 추가 엔드포인트 호출
+        mockMvc.perform(post("/payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(addPaymentDto)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(document("add-payment-success"));
+
+        // 검증: 서비스 메서드가 한 번 호출되었는지 확인
+        verify(paymentService, times(1))
+                .addPayment(memberId, cartId, orderId, quantities, impuid);
+    }
+}


### PR DESCRIPTION
1. 프론트엔드에서 카카오페이 결제 api를 호출함.
2. 백엔드에서 결제 검증을 통하여 아래에 해당될 경우 결제 에러를 호출.
 - 결제 ID가 중복일 경우
 - iamport가 호출되지 않았을 경우
 - iamport를 통해 결제했을 때 결제 상태가 "paid"가 아닐 경우

env를 통해 민감한 정보(api키) 숨김