### PR TITLE
주문의 배송 상태를 관리하고, 사용자가 각 주문의 상태를 조회할 수 있는 기능을 구현함.

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/order.js
+++ b/AutumnShop/front/Autumnshop/pages/order.js
@@ -86,9 +86,10 @@ function OrderDetails() {
   const [loading, setLoading] = useState(true);
   const [orderid, setOrderid] = useState([]);
   const [payment, setPayment] = useState([]);
-  const [page, setPage] = useState(0); // 페이지 번호
-  const [totalPages, setTotalPages] = useState(1); // 전체 페이지 수
-  const size = 10; // 페이지 크기
+  const [shippingStatus, setShippingStatus] = useState([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const size = 10;
 
   useEffect(() => {
     async function fetchOrderDetails() {
@@ -127,7 +128,7 @@ function OrderDetails() {
               Authorization: `Bearer ${JSON.parse(localStorage.getItem("loginInfo")).accessToken}`,
             },
           });
-
+          
           if (!response.ok) {
             throw new Error(`주문 ID의 정보를 불러오는 데 실패했습니다.: ${orderid}`);
           }
@@ -164,12 +165,13 @@ function OrderDetails() {
                 <th className={classes.headerCell}>수량</th>
                 <th className={classes.headerCell}>주문날짜</th>
                 <th className={classes.headerCell}>이미지</th>
+                <th className={classes.headerCell}>배송 상태</th>
               </tr>
             </thead>
             <tbody className={classes.tbody}>
               {paymentitem.map((item, idx) => (
                 <tr key={idx} className={classes.detailRow}>
-                  <td className={classes.detailCell}>{item.id}</td>
+                  <td className={classes.detailCell}>{item.order.id}</td>
                   <td className={classes.detailCell}>{item.title}</td>
                   <td className={classes.detailCell}>{item.price}</td>
                   <td className={classes.detailCell}>{item.productRate}</td>
@@ -183,6 +185,10 @@ function OrderDetails() {
                         className={classes.productImage}
                       />
                     )}
+                  </td>
+                  <td className={classes.detailCell}>
+                    {/* 배송 상태 표시 */}
+                    {item.order.delivery ? item.order.delivery.status : '정보 없음'}
                   </td>
                 </tr>
               ))}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Delivery.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Delivery.java
@@ -1,0 +1,32 @@
+package com.example.AutumnMall.Payment.domain;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@Table(name = "delivery")
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Delivery {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JsonBackReference
+    @JoinColumn(name = "order_id")
+    private Order order; // 주문과 1:1 관계
+
+    private String trackingNumber; // 송장 번호
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DeliveryStatus status = DeliveryStatus.PREPARING;
+
+    // Getters and setters
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/DeliveryStatus.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/DeliveryStatus.java
@@ -1,0 +1,8 @@
+package com.example.AutumnMall.Payment.domain;
+
+public enum DeliveryStatus {
+    PREPARING,
+    SHIPPING,
+    DELIVERED,
+    CANCELED
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Order.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Order.java
@@ -2,6 +2,7 @@ package com.example.AutumnMall.Payment.domain;
 
 import com.example.AutumnMall.Member.domain.Member;
 import com.example.AutumnMall.utils.audit.Auditable;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 
 import javax.persistence.*;
@@ -28,5 +29,9 @@ public class Order extends Auditable {
 
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
+
+    @OneToOne(mappedBy = "order")
+    @JsonManagedReference // 자식 엔티티 연결
+    private Delivery delivery; // 배송 정보
 
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/repository/DeliveryRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/repository/DeliveryRepository.java
@@ -1,0 +1,9 @@
+package com.example.AutumnMall.Payment.repository;
+
+import com.example.AutumnMall.Payment.domain.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+    Delivery findByOrderId(Long orderId);
+}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/exception/ExceptionCode.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/exception/ExceptionCode.java
@@ -15,6 +15,7 @@ public enum ExceptionCode {
     PAYMENT_ALREADY_PAID(400, "이미 처리된 결제입니다."),
     IAMPORT_NOT_FOUND(404, "결제 기능을 찾을 수 없습니다"),
     REVIEW_NOT_FOUND(500, "해당 물품의 리뷰 목록을 찾을 수 없습니다"),
+    DELIVERY_INVALID_STATUS(400, "유효하지 않은 배송상태입니다"),
     INVALID_CARTITEM_STATUS(400, "구매 가능한 수량보다 더 구매할 수 없습니다! (최대 수량: 10)"),
     INVALID_PAYMENT_STATUS(400, "유효하지 않은 결제입니다!"),
     IAMPORT_TOKEN_NOT_FOUND(400, "유효하지 않은 토큰입니다!"),


### PR DESCRIPTION
close #126  

주문 테이블에 배송 상태를 추가하여 조회할 때 주문의 속성을 추가해 DB의 배송 상태로 가져오도록 함. 추후에 관리자 페이지를 추가하여 관리자 페이지에서 배송 상태를 수동으로 업데이트할 수 있는 기능을 구현 예정