### PR TITLE
회원가입 시 이메일 인증 기능 구현

### DIFF
--- a/AutumnShop/build.gradle
+++ b/AutumnShop/build.gradle
@@ -80,6 +80,9 @@ dependencies {
     // iamport (카카오톡, 토스, 네이버페이 같은 간편 결제)
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.21'
 
+    // 인증 코드 저장 및 검증
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-mail'
     }

--- a/AutumnShop/front/Autumnshop/pages/joinform.js
+++ b/AutumnShop/front/Autumnshop/pages/joinform.js
@@ -19,6 +19,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "column",
     alignItems: "center",
     justifyContent: "center",
+    marginTop: "40px",
     width: "100%",
     maxWidth: "500px",
     height: "100%",
@@ -35,6 +36,7 @@ const useStyles = makeStyles((theme) => ({
   },
   button: {
     marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
     backgroundColor: "#000000",
     color: "#ffffff",
     '&:hover': {
@@ -68,6 +70,10 @@ const JoinForm = () => {
 
   // 상태 설정 추가
   const [email, setEmail] = useState("");
+  const [verificationCode, setVerificationCode] = useState(""); // 인증 코드 상태
+  const [message, setMessage] = useState(""); // 상태 메시지
+  const [isEmailSent, setIsEmailSent] = useState(false); // 이메일 인증 코드 전송 여부
+  const [isEmailVerified, setIsEmailVerified] = useState(false); // 이메일 인증 상태
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
   const [birthDate, setBirthDate] = useState("");
@@ -82,9 +88,91 @@ const JoinForm = () => {
     setGender(event.target.value);
   };
 
+  // 이메일 입력값 처리
+  const handleEmailChange = (event) => {
+    setEmail(event.target.value);
+  };
+
+    // 인증 코드 입력값 처리
+    const handleVerificationCodeChange = (event) => {
+      setVerificationCode(event.target.value);
+    };
+
+    // 이메일 인증 코드 요청 함수
+    const handleSendVerificationEmail = async () => {
+      if (!email) {
+        setMessage("이메일을 입력해주세요.");
+        return;
+      }
+      
+      if (!email.includes("@naver.com")) {
+        setMessage("네이버 이메일 및 '@'를 포함해야 합니다.");
+        return;
+      }
+    
+  
+      try {
+        const response = await fetch(`http://localhost:8080/email/sendEmail`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ email: email }), 
+        });
+        console.log(response);
+  
+        if (response.ok) {
+          setMessage("인증 코드가 이메일로 전송되었습니다.");
+          setIsEmailSent(true); // 인증 코드 전송 완료 표시
+        } else {
+          const data = await response.text();
+          setMessage(`Error: ${data}`);
+        }
+      } catch (error) {
+        console.error("Error:", error);
+        setMessage("이메일 인증 코드 전송에 실패했습니다.");
+      }
+    };
+  
+    // 이메일 인증 코드 검증 함수
+    const handleVerifyEmailCode = async () => {
+
+      try {
+        const response = await fetch("http://localhost:8080/email/verify", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+           email: email,
+            code: verificationCode,
+          }),
+        });
+  
+        if (response.ok) {
+          setMessage("인증 코드가 확인되었습니다. 회원가입을 진행하세요.");
+          setIsEmailVerified(true); // 인증 완료 시 true로 설정
+        } else {
+          const data = await response.text();
+          setMessage(`Error: ${data}`);
+          setIsEmailVerified(false); // 인증 실패 시 false로 설정
+        }
+      } catch (error) {
+        console.error("Error:", error);
+        setMessage("인증 코드 검증에 실패했습니다.");
+        setIsEmailVerified(false); // 인증 실패 시 false로 설정
+      }
+    };
+  
+
   // 회원가입 제출
   const handleSubmit = async (event) => {
     event.preventDefault();
+
+    if (!isEmailVerified) {
+      alert("이메일 인증을 먼저 완료해주세요.");
+      return;
+    }
 
     const phonePattern = /^(010|031|032)-\d{3,4}-\d{4}$/;
     if (!phonePattern.test(phone)) {
@@ -148,16 +236,53 @@ const JoinForm = () => {
           onChange={(e) => setName(e.target.value)}
           className={classes.textField}
         />
-        <TextField
-          label="이메일"
-          type="email"
-          variant="outlined"
-          fullWidth
-          required
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className={classes.textField}
-        />
+      {/* 이메일 입력 */}
+      <TextField
+        label="이메일 (네이버 메일)"
+        variant="outlined"
+        fullWidth
+        required
+        value={email}
+        onChange={handleEmailChange}
+        helperText="'네이버' 이메일을 입력하세요 (@을 포함해야 합니다)"
+      />
+
+      {/* 인증 코드 전송 버튼 */}
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleSendVerificationEmail}
+        disabled={isEmailSent}
+        className={classes.button}
+      >
+        인증 코드 전송
+      </Button>
+
+      {/* 인증 코드 입력 */}
+      {isEmailSent && (
+        <div>
+          <TextField
+            label="인증 코드"
+            variant="outlined"
+            fullWidth
+            required
+            value={verificationCode}
+            onChange={handleVerificationCodeChange}
+            helperText="이메일로 받은 인증 코드를 입력하세요."
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleVerifyEmailCode}
+            className={classes.button}
+          >
+            인증 코드 확인
+          </Button>
+        </div>
+      )}
+
+      {/* 메시지 출력 */}
+      {message && <Typography color="error">{message}</Typography>}
         <TextField
           label="암호"
           type="password"
@@ -208,6 +333,7 @@ const JoinForm = () => {
           zipCode={zipCode}
           detailAdd={detailAddress}
         />
+        
 
         <Button type="submit" variant="contained" className={classes.button} fullWidth>
           회원가입

--- a/AutumnShop/front/Autumnshop/pages/welcome.js
+++ b/AutumnShop/front/Autumnshop/pages/welcome.js
@@ -58,46 +58,8 @@ const MainPage = () => {
   const [clothingProducts, setClothingProducts] = useState([]);
   const [shoesProducts, setShoesProducts] = useState([]);
   const [accessoryProducts, setAccessoryProducts] = useState([]);
-  const [email, setEmail] = useState(""); // 이메일 상태 관리
-  const [message, setMessage] = useState(""); // 이메일 상태 메시지
   const [value, setValue] = useState(0);
   const classes = useStyles();
-
-
-  // 이메일 입력값 처리
-  const handleEmailChange = (event) => {
-    setEmail(event.target.value);
-  };
-
-  // 이메일 인증 코드 요청 함수
-  const handleSendVerificationEmail = async () => {
-
-    const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
-    if (!loginInfo || !loginInfo.accessToken) {
-      console.error("로그인 정보가 없습니다.");
-      return;
-    }
-    if (!email) {
-      setMessage("이메일을 입력해주세요.");
-      return;
-    }
-
-    try {
-      const response = await fetch("http://localhost:8080/sendEmail",
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${loginInfo.accessToken}`,
-          },
-        }
-      )
-      
-      const data = await response.text();
-      console.log(data);
-    } catch (error) {
-      console.error("Error:", error);
-    }
-  };
 
   const mainRef = useRef(null);
   const clothingRef = useRef(null);
@@ -243,18 +205,6 @@ const MainPage = () => {
         <ProductSection title="신발" subtitle="인기 신발" products={shoesProducts} sectionRef={shoesRef} />
         <ProductSection title="악세서리" subtitle="인기 악세서리" products={accessoryProducts} sectionRef={accessoryRef} />
       </div>
-      <div>
-      <h2>이메일 인증</h2>
-      <input
-        type="email"
-        placeholder="이메일을 입력하세요"
-        value={email}
-        onChange={handleEmailChange}
-        required
-      />
-      <button onClick={handleSendVerificationEmail}>인증 코드 보내기</button>
-      <p>{message}</p>
-    </div>
 
         <div>
     <button onClick={handleBatchDelete} >

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Email/controller/EmailController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Email/controller/EmailController.java
@@ -1,39 +1,60 @@
 package com.example.AutumnMall.Email.controller;
 
 import com.example.AutumnMall.Email.service.EmailService;
-import com.example.AutumnMall.security.jwt.util.IfLogin;
-import com.example.AutumnMall.security.jwt.util.LoginUserDto;
+import com.example.AutumnMall.Member.service.MemberService;
+import com.example.AutumnMall.exception.BusinessLogicException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
-import javax.mail.MessagingException;
-import java.util.Random;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import javax.mail.MessagingException;
+import java.util.Map;
+
+@Slf4j
 @RestController
+@RequestMapping("/email")
 public class EmailController {
 
+    private final EmailService emailService;
+    private final MemberService memberService;
+
     @Autowired
-    private EmailService emailService;
-
-    @PostMapping("/sendEmail")
-    public String sendVerificationEmail(@IfLogin LoginUserDto loginUserDto) {
-        String email = loginUserDto.getEmail();
-
-        // 인증 코드 생성
-        String verificationCode = generateVerificationCode();
-
-        try {
-            // 이메일 보내기
-            emailService.sendVerificationEmail(email, verificationCode);
-            return "인증 코드가 이메일로 전송되었습니다.";
-        } catch (MessagingException e) {
-            return "이메일 전송에 실패했습니다.";
-        }
+    public EmailController(EmailService emailService, MemberService memberService) {
+        this.emailService = emailService;
+        this.memberService = memberService;
     }
 
-    // 인증 코드 생성 (6자리 숫자)
-    private String generateVerificationCode() {
-        Random random = new Random();
-        return String.format("%06d", random.nextInt(1000000));
+    // 이메일 인증 코드 전송
+    @PostMapping("/sendEmail")
+    public ResponseEntity<String> sendVerificationEmail(@RequestBody Map<String, String> request) throws MessagingException {
+        String email = request.get("email");
+
+        try {
+            // 이메일이 존재하는지 확인 만약 있다면 에러 처리, 없다면 커스텀 에러 처리로 전달하여 정상적 진행
+            if (memberService.findByEmail(email) != null) {
+                // 이메일이 이미 존재하는 경우
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이미 가입된 이메일입니다.");
+            }
+            // 해당 이메일로 가입된 멤버가 없을 경우 정상적으로 진행
+        } catch (BusinessLogicException e){
+            emailService.sendVerificationEmail(email);
+            return ResponseEntity.ok("인증 코드가 이메일로 전송되었습니다.");
+        } catch (Exception e) {
+            log.error("이메일 전송 실패: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이메일 전송에 실패했습니다.");
+        }
+        return null;
+    }
+
+    // 이메일 인증 코드 검증
+    @PostMapping("/verify")
+    public ResponseEntity<String> verifyEmail(@RequestBody Map<String, String> request) {
+        String email = request.get("email");
+        String code = request.get("code");
+
+        boolean isValid = emailService.verifyEmailCode(email, code);
+        return isValid ? ResponseEntity.ok("이메일 인증이 완료되었습니다.") : ResponseEntity.badRequest().body("인증 코드가 올바르지 않습니다.");
     }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/config/SecurityConfig.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                             .antMatchers(
                                     "/members/signup", "/members/login", "/members/refreshToken"
                             ).permitAll()
+                            .antMatchers("/email/**").permitAll()  // 이메일 인증 관련 경로도 모두 허용
 
                             // 접속 안 해도 볼 수 있음
                             .antMatchers(HttpMethod.GET, "/categories/**", "/products/**").permitAll()

--- a/AutumnShop/src/main/resources/application.yml
+++ b/AutumnShop/src/main/resources/application.yml
@@ -52,3 +52,6 @@ spring:
     scheduling:
       pool:
         size: 10
+  redis:
+    host: localhost
+    port: 6379


### PR DESCRIPTION
1. 회원가입 시 이메일을 입력하고 옆에 인증 버튼을 누르면 입력한 이메일에 인증코드가 보내지도록 함.
2. 이메일 아래에 입력할 수 있는 '인증코드' 란이 주어지고 이메일로 받은 인증코드를 입력할 수 있어야 함.
3. 인증코드가 잘못되면 잘못됐다는 알림을 보내고, 맞다면 인증코드가 맞다고 경고창을 띄움.
4. redis를 이용하여 인증코드를 10분 내에 검증해야 하며 인증코드가 검증되면, 회원가입이 성공적으로 완료되도록 함.
5. 이메일 입력 시 네이버 메일을 사용한다는 것을 사용자에게 알리도록 함. (네이버 메일만 사용하도록 조건 추가)

+ 테스트였던 welcome의 이메일 코드 보내기 삭제