### PR TITLE
회원가입 시, 비밀번호를 찾고자 할 때 사용자의 이메일 인증을 통하고, 인증이 성공적이라면 비밀번호를 변경하도록 함

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/login.js
+++ b/AutumnShop/front/Autumnshop/pages/login.js
@@ -154,7 +154,7 @@ const Login = () => {
             회원가입
           </Button>
         </Link>
-        <Link href="/findpassword" passHref>
+        <Link href="/resetPassword/emailAuth" passHref>
           <Button className={classes.linkButton} fullWidth>
             암호를 잊었어요
           </Button>

--- a/AutumnShop/front/Autumnshop/pages/resetPassword/emailAuth.js
+++ b/AutumnShop/front/Autumnshop/pages/resetPassword/emailAuth.js
@@ -1,0 +1,147 @@
+import React, { useState } from "react";
+import { Container, Typography, TextField, Button, Box } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: "40px",
+    width: "100%",
+    maxWidth: "400px",
+    backgroundColor: "#ffffff",
+    padding: "20px",
+    borderRadius: "8px",
+    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+  },
+  form: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+  },
+  button: {
+    marginTop: "16px",
+    backgroundColor: "#000000",
+    color: "#ffffff",
+    '&:hover': {
+      backgroundColor: "#333",
+    },
+  },
+  textField: {
+    marginTop: "32px",
+    marginBottom: "16px",
+  },
+}));
+
+const EmailAuth = () => {
+  const classes = useStyles();
+  const [email, setEmail] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
+  const [message, setMessage] = useState("");
+  const [isEmailSent, setIsEmailSent] = useState(false);
+  
+  const handleEmailChange = (event) => {
+    setEmail(event.target.value);
+  };
+
+  const handleVerificationCodeChange = (event) => {
+    setVerificationCode(event.target.value);
+  };
+
+  const handleSendVerificationEmail = async () => {
+    if (!email.includes("@naver.com")) {
+      setMessage("네이버 이메일만 입력 가능합니다.");
+      return;
+    }
+
+    try {
+      const response = await fetch("http://localhost:8080/members/password/reset-request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+
+      if (response.ok) {
+        setMessage("인증 코드가 이메일로 전송되었습니다.");
+        setIsEmailSent(true);
+      } else {
+        setMessage("이메일 전송 실패.");
+      }
+    } catch (error) {
+      setMessage("서버 오류. 다시 시도해주세요.");
+    }
+  };
+
+  const handleVerifyEmailCode = async () => {
+    try {
+      const response = await fetch("http://localhost:8080/members/password/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, code: verificationCode }),
+      });
+
+      if (response.ok) {
+        setMessage("인증 성공!");
+        localStorage.setItem("email", email);
+        localStorage.setItem("verificationCode", verificationCode);
+
+        window.location.href = "./passwordReset"; // 로그인 페이지로 리디렉션
+      } else {
+        setMessage("인증 코드가 올바르지 않습니다.");
+      }
+    } catch (error) {
+      setMessage("서버 오류. 다시 시도해주세요.");
+    }
+  };
+
+  return (
+    <Container className={classes.container}>
+      <Typography variant="h5">이메일 인증</Typography>
+      <Box className={classes.form}>
+        <TextField
+          label="이메일 (네이버 메일)"
+          variant="outlined"
+          fullWidth
+          required
+          value={email}
+          onChange={handleEmailChange}
+          className={classes.textField}
+        />
+        <Button
+          variant="contained"
+          className={classes.button}
+          onClick={handleSendVerificationEmail}
+          disabled={isEmailSent}
+        >
+          인증 코드 전송
+        </Button>
+        {isEmailSent && (
+          <>
+            <TextField
+              label="인증 코드"
+              variant="outlined"
+              fullWidth
+              required
+              value={verificationCode}
+              onChange={handleVerificationCodeChange}
+              className={classes.textField}
+            />
+            <Button
+              variant="contained"
+              className={classes.button}
+              onClick={handleVerifyEmailCode}
+            >
+              인증 코드 확인
+            </Button>
+          </>
+        )}
+        {message && <Typography color="error">{message}</Typography>}
+      </Box>
+    </Container>
+  );
+};
+
+export default EmailAuth;

--- a/AutumnShop/front/Autumnshop/pages/resetPassword/passwordReset.js
+++ b/AutumnShop/front/Autumnshop/pages/resetPassword/passwordReset.js
@@ -1,0 +1,146 @@
+import React, { useState } from "react";
+import { TextField, Button, Container, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    maxWidth: "500px",
+    height: "100%",
+    margin: "0 auto",
+    backgroundColor: "#ffffff",
+    padding: "20px",
+    borderRadius: "8px",
+    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+  },
+  form: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+  },
+  button: {
+    marginTop: theme.spacing(2),
+    backgroundColor: "#000000",
+    color: "#ffffff",
+    '&:hover': {
+      backgroundColor: "#333",
+    },
+  },
+  textField: {
+    marginBottom: theme.spacing(2),
+    '& .MuiOutlinedInput-root': {
+      '& fieldset': {
+        borderColor: "#ccc",
+      },
+      '&:hover fieldset': {
+        borderColor: "#888",
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: "#888",
+      },
+    },
+    '& .MuiInputLabel-root': {
+      color: "#888",
+    },
+    '& .MuiInputLabel-root.Mui-focused': {
+      color: "#888",
+    },
+  },
+  errorMessage: {
+    color: "red",
+    marginTop: "10px",
+  },
+}));
+
+const PasswordReset = () => {
+  const classes = useStyles();
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handlePasswordReset = async () => {
+    if (newPassword !== confirmPassword) {
+      setErrorMessage("새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.");
+      return;
+    }
+
+    const email = localStorage.getItem("email");
+    const inputCode = localStorage.getItem("verificationCode");
+
+    try {
+      const response = await fetch("http://localhost:8080/members/password/change", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: email,
+          newPassword: newPassword,
+          inputCode: inputCode,
+        }),
+      });
+
+      if (response.ok) {
+        alert("비밀번호가 성공적으로 변경되었습니다.");
+        setNewPassword("");
+        setConfirmPassword("");
+        setErrorMessage("");
+
+        localStorage.removeItem("email");
+        localStorage.removeItem("verificationCode");
+        
+        window.location.href = "/login"; // 로그인 페이지로 리디렉션
+      } else {
+        throw new Error("비밀번호 변경에 실패했습니다.");
+      }
+    } catch (error) {
+      setErrorMessage(error.message);
+    }
+  };
+
+  return (
+    <Container className={classes.container}>
+      <Typography variant="h6">비밀번호 재설정</Typography>
+      <form className={classes.form} noValidate autoComplete="off">
+        <TextField
+          label="새 비밀번호"
+          variant="outlined"
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          fullWidth
+          required
+          className={classes.textField}
+        />
+        <TextField
+          label="새 비밀번호 확인"
+          variant="outlined"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          fullWidth
+          required
+          className={classes.textField}
+        />
+        {errorMessage && (
+          <Typography className={classes.errorMessage} variant="body2">
+            {errorMessage}
+          </Typography>
+        )}
+        <Button
+          variant="contained"
+          className={classes.button}
+          onClick={handlePasswordReset}
+        >
+          비밀번호 변경
+        </Button>
+      </form>
+    </Container>
+  );
+};
+
+export default PasswordReset;

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Member/repository/MemberRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByMemberId(Long memberId);
+
+    boolean existsByEmail(String email);
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Member/service/MemberService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Member/service/MemberService.java
@@ -105,17 +105,17 @@ public class MemberService {
 
     // mapper를 사용할 경우 평문으로 저장되므로 서비스단에서만 처리
     @Transactional
-    public Member updateMemberPassword(Long memberId, String newPassword){
+    public Member updateMemberPassword(String email, String newPassword){
         try {
-            Member member = memberRepository.findById(memberId)
+            Member member = memberRepository.findByEmail(email)
                     .orElseThrow(() -> {
-                        log.error("회원이 존재하지 않습니다. 회원Id: {}", + memberId);
+                        log.error("회원이 존재하지 않습니다. 회원Email: {}" , email);
                         return new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND);
                     });
             member.setPassword(passwordEncoder.encode(newPassword));
 
             // 로그 추가: 비밀번호 수정
-            log.info("회원 {}의 비밀번호가 변경되었습니다.", memberId);
+            log.info("회원 {}의 비밀번호가 변경되었습니다.", email);
 
             return memberRepository.save(member);
         } catch (BusinessLogicException e) {
@@ -125,5 +125,10 @@ public class MemberService {
             log.error("멤버 조회 실패 (예상치 못한 예외): {}", e.getMessage(), e);
             throw new BusinessLogicException(ExceptionCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Transactional
+    public boolean existsByEmail(String email){
+        return memberRepository.existsByEmail(email);
     }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/config/SecurityConfig.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                             ).permitAll()
                             .antMatchers("/email/**").permitAll()  // 이메일 인증 관련 경로도 모두 허용
 
+                            .antMatchers("/members/password/**").permitAll()
                             // 접속 안 해도 볼 수 있음
                             .antMatchers(HttpMethod.GET, "/categories/**", "/products/**").permitAll()
 


### PR DESCRIPTION
close #69 

( 회원의 패스워드를 변경할 때 memberId가 아닌 email을 기준으로 조회하도록 변경함 )

1. 회원가입 시, 비밀번호를 찾고자 할 때 사용자의 찾고자 하는 이메일을 입력하는 페이지로 이동함
2. 이메일이 네이버 이메일이여야 하며, 맞다면 해당 네이버 이메일로 실제 인증 코드를 보냄.
3. 인증 코드가 맞다면 해당 이메일의 비밀번호를 변경하는 페이지로 이동하고 localStorage에 이메일과 사용자가 입력했던 인증코드를 저장함과 동시에 redis에서 이메일, 인증코드 저장
4. 인증 코드가 맞지 않다면 경고창을 출력하고 비밀번호를 변경하는 페이지로 넘어가지 않음.
5. 새 비밀번호를 입력 후 변경하고자 했을 때 localStorage에 저장한 이메일, 인증코드와 redis와 맞을 때만 변경되도록 함