### PR TITLE
동시성 문제 해결을 위한 락(Lock) 처리 완료

### DIFF
--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
@@ -158,9 +158,8 @@ public class PaymentService {
                 CartItem cartItem = iterator.next();
                 int quantity = quantityIterator.next();
 
-                Product product = cartItem.getProduct();
-                System.out.println(product.getPrice());
-
+                Product product = productRepository.findByIdWithLock(cartItem.getProduct().getId())
+                        .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PRODUCT_NOT_FOUND));
 
                 if(product.getRating().getCount() < quantity){
                     log.error("구매 수량 {}가 잔여 수량보다 많습니다. 상품: {}", quantity, product.getTitle());  // 오류 로그

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/repository/ProductRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/repository/ProductRepository.java
@@ -4,7 +4,11 @@ import com.example.AutumnMall.Product.domain.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import javax.persistence.LockModeType;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
@@ -13,5 +17,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findImageUrlById(Long id);
 
     Optional<Product> findById(Long id);
+
+    // 물품 개수 업데이트 시 비관적 락을 이용함
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.id = :productId")
+    Optional<Product> findByIdWithLock(@Param("productId") Long productId);
 
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ReviewService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ReviewService.java
@@ -44,7 +44,7 @@ public class ReviewService {
                         log.error("회원이 존재하지 않습니다. 회원Id: {}", + memberId);
                         return new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND);
                     });
-            Product product = productRepository.findById(productId)
+            Product product = productRepository.findByIdWithLock(productId)  // 비관적 락 적용된 조회
                     .orElseThrow(() -> {
                         log.error("물품이 존재하지 않습니다. 물품Id: {}", productId);
                         return new BusinessLogicException(ExceptionCode.PRODUCT_NOT_FOUND);


### PR DESCRIPTION
close #134 

여러 사용자가 동일한 데이터를 수정하는 과정에서 오류가 생기는 것을 방지하기 위해 락(Lock) 처리 함 해당되는 서비스는 여러 사용자가 동시에 접근이 가능한 물품의 개수를 수정하는 트랜잭션과 리뷰를 등록하는 서비스가 해당됨. 다른 서비스들은 유저 개개인의 서비스이기 때문에 굳이 문제가 되지 않는다고 판단함.
회원가입은 새로운 행을 추가하고 member와 email이 유일키로 설정되어 있어 큰 문제가 되지 않는다고 판단함.