### PR TITLE
사용자 맞춤 추천 물품 목록 기능 구현

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/order.js
+++ b/AutumnShop/front/Autumnshop/pages/order.js
@@ -172,15 +172,15 @@ function OrderDetails() {
               {paymentitem.map((item, idx) => (
                 <tr key={idx} className={classes.detailRow}>
                   <td className={classes.detailCell}>{item.order.id}</td>
-                  <td className={classes.detailCell}>{item.title}</td>
-                  <td className={classes.detailCell}>{item.price}</td>
-                  <td className={classes.detailCell}>{item.productRate}</td>
+                  <td className={classes.detailCell}>{item.product.title}</td>
+                  <td className={classes.detailCell}>{item.product.price}</td>
+                  <td className={classes.detailCell}>{item.product.rating.rate}</td>
                   <td className={classes.detailCell}>{item.quantity}</td>
                   <td className={classes.detailCell}>{item.date}</td>
                   <td className={classes.detailCell}>
-                    {item.imageUrl && (
+                    {item.product.imageUrl && (
                       <img
-                        src={item.imageUrl}
+                        src={item.product.imageUrl}
                         alt={`Product ${idx + 1}`}
                         className={classes.productImage}
                       />

--- a/AutumnShop/front/Autumnshop/pages/paymentList/[param].js
+++ b/AutumnShop/front/Autumnshop/pages/paymentList/[param].js
@@ -155,7 +155,7 @@ const paymentList = () => {
   
       // 정렬된 항목으로 가격 합계 계산
       sortedItems.forEach((item) => {
-        itemTotalPrice += item.price * item.quantity;
+        itemTotalPrice += item.product.price * item.quantity;
       });
   
       // 상태가 변경된 경우에만 업데이트
@@ -190,14 +190,14 @@ const paymentList = () => {
             paymentItems.content.map((item, index) => (
               <tr key={item.id} className={classes.tableRow}>
                 <td className={classes.tableCell}>{index + 1}</td>
-                <td className={classes.tableCell}>{item.title}</td>
-                <td className={classes.tableCell}>{item.price}</td>
-                <td className={classes.tableCell}>{item.productRate}</td>
+                <td className={classes.tableCell}>{item.product.title}</td>
+                <td className={classes.tableCell}>{item.product.price}</td>
+                <td className={classes.tableCell}>{item.product.rating.rate}</td>
                 <td className={classes.tableCell}>{item.quantity}</td>
                 <td className={classes.tableCell}>
-                  {item.imageUrl && (
+                  {item.product.imageUrl && (
                     <img
-                      src={item.imageUrl}
+                      src={item.product.imageUrl}
                       alt={`Product ${index + 1}`}
                       style={{ width: "100px", alignSelf: "center" }}
                     />

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/controller/PaymentController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/controller/PaymentController.java
@@ -8,6 +8,7 @@ import com.example.AutumnMall.security.jwt.util.IfLogin;
 import com.example.AutumnMall.security.jwt.util.LoginUserDto;
 import com.example.AutumnMall.Payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -55,4 +56,8 @@ public class PaymentController {
         return ResponseEntity.ok(paymentService.getOrderPayment(orderId));
     }
 
+    @GetMapping("/get")
+    public ResponseEntity<List<Payment>> getPaymentListMember(@IfLogin LoginUserDto loginUserDto){
+        return ResponseEntity.ok(paymentService.getPayment(loginUserDto.getMemberId()));
+    }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Payment.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/domain/Payment.java
@@ -1,6 +1,7 @@
 package com.example.AutumnMall.Payment.domain;
 
 import com.example.AutumnMall.Member.domain.Member;
+import com.example.AutumnMall.Product.domain.Product;
 import com.example.AutumnMall.utils.audit.Auditable;
 import lombok.*;
 
@@ -24,11 +25,10 @@ public class Payment extends Auditable {
     private String impuid;
     private String status;
 
-    private String imageUrl;
-    private Long productId;
-    private Double price;
-    private String title;
-    private Double productRate;
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
+
     private int quantity;
 
     @ManyToOne

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
@@ -175,8 +175,7 @@ public class PaymentService {
 
                 userPayment = userPayment.toBuilder()
                         .id(null)  // Id는 null로 설정
-                        .productId(product.getId())
-                        .productRate(product.getRating().getRate())
+                        .product(product)
                         .quantity(quantity)
                         .date(localDate)
                         .impuid(impuid)

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/controller/ProductController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/controller/ProductController.java
@@ -3,12 +3,15 @@ package com.example.AutumnMall.Product.controller;
 import com.example.AutumnMall.Product.domain.Product;
 import com.example.AutumnMall.Product.dto.AddProductDto;
 import com.example.AutumnMall.Product.service.ProductService;
+import com.example.AutumnMall.security.jwt.util.IfLogin;
+import com.example.AutumnMall.security.jwt.util.LoginUserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -37,8 +40,9 @@ public class ProductController {
         return ResponseEntity.ok(productService.getProduct(id));
     }
 
-    @GetMapping("/image/{id}")
-    public ResponseEntity<Optional<Product>> getImageUrl(@PathVariable Long id){
-        return ResponseEntity.ok(productService.getImageUrl(id));
+    // 헤더로 로그인 한 사용자만 받을 수 있음을 위 메소드와 차별화함. (오버로딩)
+    @GetMapping("/getCategory/{categoryId}")
+    public ResponseEntity<List<Product>> getImageUrl(@IfLogin LoginUserDto loginUserDto, @PathVariable Long categoryId){
+        return ResponseEntity.ok(productService.getProductsByCategoryId(categoryId));
     }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/repository/ProductRepository.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/repository/ProductRepository.java
@@ -1,6 +1,7 @@
 package com.example.AutumnMall.Product.repository;
 
 import com.example.AutumnMall.Product.domain.Product;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,14 +10,18 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import javax.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<Product> findProductByCategory_id(Long categoryId, Pageable pageable);
 
+    List<Product> findByCategory_id(Long categoryId);
+
     Optional<Product> findImageUrlById(Long id);
 
-    Optional<Product> findById(Long id);
+    @NotNull
+    Optional<Product> findById(@NotNull Long id);
 
     // 물품 개수 업데이트 시 비관적 락을 이용함
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ProductService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ProductService.java
@@ -17,7 +17,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+
+import static org.springframework.data.jpa.domain.AbstractPersistable_.id;
 
 @Slf4j
 @Service
@@ -95,9 +98,9 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Product> getImageUrl(Long id){
+    public List<Product> getProductsByCategoryId(Long categoryId){
         try {
-            return productRepository.findImageUrlById(id);
+            return productRepository.findByCategory_id(categoryId);
         } catch (Exception e) {
             log.error("해당 상품의 이미지 불러오기 실패 {} ", e.getMessage(), e);
             throw new BusinessLogicException(ExceptionCode.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
1. 사용자의 구매 내역을 기반으로 추천 물품을 제공합니다.
2. 구매 내역에서 사용자의 memberId를 기준으로 정보들을 받고, 많이 구매한 물품의 카테고리 중 랜덤으로 사용자에게 보여지도록 함.
3. 최대 5개로 제한하고, 5개 미만이라면 그에 맞게 렌더링돼야 합니다.

 + 기존의 payment의 product를 업데이트 하는 과정에서, 그대로 payment에 외래키를 설정하지 않고 저장하여 product가 실수로 삭제돼도 민감한 구매 정보는 문제없이 하도록 하였으나, categoryId를 기준으로 불러와 랜덤으로 렌더링하는 과정에서 categoryId가 payment 정보에 없어 payment에 product를 외래키로 설정하여 categoryId 정보를 받아오도록 했습니다. 사실 그대로 categoryId를 다시 담아서 해도 상관은 없으나 물건을 삭제하는 기능과 서비스를 구현하지 않는다면 후에 문제가 없을 거라 판단하여 외래키 설정을 했습니다.