### PR TITLE
물품 등록 페이지 이동 구현

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/addProduct.js
+++ b/AutumnShop/front/Autumnshop/pages/addProduct.js
@@ -95,6 +95,7 @@ const useStyles = makeStyles(() => ({
 export default function AddProduct() {
   const classes = useStyles();
   const [categories, setCategories] = useState([]);
+  const [isAdmin, setIsAdmin] = useState(null);
   const [formData, setFormData] = useState({
     title: "",
     price: "",
@@ -104,6 +105,46 @@ export default function AddProduct() {
     image: null,
   });
   const [error, setError] = useState("");
+
+  useEffect(() => {
+    const getUserInfo = async () => {
+      const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+
+      if (!loginInfo || !loginInfo.accessToken) {
+        window.location.href = "/login";
+        return;
+      }
+
+      try {
+        const response = await fetch("http://localhost:8080/members/info", {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${loginInfo.accessToken}`,
+          },
+        });
+
+        if(!response.ok){
+          throw new error;
+        }
+
+        const data = await response.json();
+
+        if (data.roles.some(role => role.name === "ROLE_ADMIN")) {
+          setIsAdmin(true);
+        } else {
+          setIsAdmin(false);
+        }
+
+        if(data.roles[0].name != "ROLE_ADMIN"){
+          throw error;
+        }
+      } catch (error) {
+        window.location.href = "/welcome";
+      }
+    };
+
+    getUserInfo();
+  }, []);
 
   useEffect(() => {
     async function fetchCategories() {
@@ -165,6 +206,17 @@ export default function AddProduct() {
       setError("상품 등록 중 오류 발생");
     }
   };
+
+  
+  // 아직 관리자 여부 확인이 안 되었으면 로딩 표시
+  if (isAdmin === null) {
+    return <p>로딩 중...</p>;
+  }
+
+  // ROLE_ADMIN이 아니면 아무것도 렌더링하지 않음
+  if (!isAdmin) {
+    return null;
+  }
 
   return (
     <div className={classes.container}>

--- a/AutumnShop/front/Autumnshop/pages/mypage/index.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/index.js
@@ -174,6 +174,21 @@ const MyPage = () => {
               variant="outlined"
               InputProps={{ readOnly: true }}
             />
+            {/* 관리자인 경우에만 결제 관리 버튼 추가 */}
+            {userInfo.roles[0].name === "ROLE_ADMIN" && (
+              <Button
+                variant="contained"
+                sx={{
+                  marginTop: "20px",
+                  backgroundColor: "#000",
+                  color: "#fff",
+                  "&:hover": { backgroundColor: "#333" },
+                }}
+                onClick={() => (window.location.href = "/addProduct")}
+              >
+                물품 추가
+              </Button>
+            )}
           </Box>
         );
       case "mileage":


### PR DESCRIPTION
close #147 

1. 내 정보 페이지에서 로그인 한 사용자의 권한이 관리자('ADMIN')일 때만 물품 등록 페이지 버튼이 표시됨
2. 물품 등록 페이지로 이동되었을 때도 사용자의 권한이 관리자('ADMIN')이 아니면, 아무런 반응과 렌더링없이 welcome 페이지로 이동됨.
3. 권한이 관리자라면, 물품 등록 페이지가 정상적으로 렌더링되고 잘 작동함.