### PR TITLE
관리자 유저 판매 지표 확인 기능 완료

### DIFF
--- a/AutumnShop/front/Autumnshop/components/mypage/sellChart.js
+++ b/AutumnShop/front/Autumnshop/components/mypage/sellChart.js
@@ -1,0 +1,264 @@
+import React, { useEffect, useState } from "react";
+import { makeStyles } from "@mui/styles";
+import { Typography, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, Paper } from "@mui/material";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
+
+const useStyles = makeStyles({
+    chartContainer: {
+        height: 300, 
+        marginBottom: 30,
+        width: 700,
+    },
+    tableContainer: {
+        marginTop: 20,
+    },
+    title: {
+        marginTop: 60,
+    }
+});
+
+async function getPaymentList(loginInfo, setPaymentList) {
+    try {
+        const paymentResponse = await fetch("http://localhost:8080/payment/findAll", {
+            method: "GET",
+            headers: { Authorization: `Bearer ${loginInfo.accessToken}` }
+        });
+        const paymentData = await paymentResponse.json();
+        setPaymentList(paymentData);
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+const SellChart = () => {
+    const classes = useStyles();
+    const [paymentList, setPaymentList] = useState([]);
+    const [isAdmin, setIsAdmin] = useState(false);
+    const currentYear = new Date().getFullYear();  // 현재 년도
+
+    useEffect(() => {
+        const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
+        const getUserInfo = async () => {
+      
+            if (!loginInfo || !loginInfo.accessToken) {
+              window.location.href = "/login";
+              return;
+            }
+      
+            try {
+              const response = await fetch("http://localhost:8080/members/info", {
+                method: "GET",
+                headers: {
+                  Authorization: `Bearer ${loginInfo.accessToken}`,
+                },
+              });
+      
+              if(!response.ok){
+                throw new error;
+              }
+      
+              const data = await response.json();
+      
+              if (data.roles.some(role => role.name === "ROLE_ADMIN")) {
+                setIsAdmin(true);
+              } else {
+                setIsAdmin(false);
+              }
+      
+              if(data.roles[0].name != "ROLE_ADMIN"){
+                throw error;
+              }
+            } catch (error) {
+              window.location.href = "/welcome";
+            }
+          };
+      
+          getUserInfo();
+        getPaymentList(loginInfo, setPaymentList);
+    }, []);
+
+    const productSales = {};
+    const yearlySales = {};
+    const monthlySales = {};
+    const currentYearSales = {}; // 이번 년도 판매량
+
+    paymentList.forEach((payment) => {
+        const productId = payment.product.id;
+        const productName = payment.product.title;
+        const quantity = payment.quantity;
+        const price = payment.product.price;
+        const [year, month] = payment.date;
+
+        // 이번 년도 판매량만 필터링
+        if (year === currentYear) {
+            if (!productSales[productId]) {
+                productSales[productId] = { name: productName, totalSales: 0, totalRevenue: 0 };
+            }
+            productSales[productId].totalSales += quantity;
+            productSales[productId].totalRevenue += quantity * price;
+
+            if (!currentYearSales[productName]) currentYearSales[productName] = 0;
+            currentYearSales[productName] += quantity * price;
+        }
+
+        // 연도별 매출
+        if (!yearlySales[year]) yearlySales[year] = 0;
+        yearlySales[year] += quantity * price;
+
+        const monthKey = `${year}-${month.toString().padStart(2, "0")}`;
+        if (!monthlySales[monthKey]) monthlySales[monthKey] = 0;
+        monthlySales[monthKey] += quantity * price;
+    });
+
+    const formatYAxisTicks = (value) => {
+        if (value >= 100000000) {
+            return `${(value / 100000000).toFixed(1)}억`;
+        } else if (value >= 10000) {
+            return `${(value / 10000).toFixed(1)}만`;
+        }
+        return value;
+    };
+
+    const formatRevenue = (value) => {
+        return value.toLocaleString();
+    };
+
+    const chartData = Object.values(productSales).map((product) => ({
+        name: product.name,
+        sales: product.totalSales,
+    }));
+
+    const tableData = Object.values(productSales);
+    const totalRevenue = tableData.reduce((sum, product) => sum + product.totalRevenue, 0);
+
+    const yearlySalesData = Object.keys(yearlySales).map((year) => ({
+        year,
+        revenue: yearlySales[year],
+    }));
+
+    const monthlySalesData = Object.keys(monthlySales)
+    .map((month) => ({
+        month,
+        revenue: monthlySales[month],
+    }))
+    .sort((a, b) => {
+        const [yearA, monthA] = a.month.split("-");
+        const [yearB, monthB] = b.month.split("-");
+        return new Date(yearA, monthA - 1) - new Date(yearB, monthB - 1);  // 날짜를 비교하여 정렬
+    });
+
+    if(!isAdmin){
+        return null;
+    }
+
+    return (
+        <div className={classes.sellContainer}>
+            <Typography variant="h5" align="center" gutterBottom>
+                이번 년도 판매량
+            </Typography>
+            <div className={classes.chartContainer}>
+                <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={chartData}>
+                        <XAxis dataKey="name" />
+                        <YAxis tickFormatter={formatYAxisTicks} />
+                        <Tooltip formatter={(value) => formatRevenue(value)} />
+                        <Bar dataKey="sales" fill="#8884d8" />
+                    </BarChart>
+                </ResponsiveContainer>
+            </div>
+
+            <TableContainer component={Paper} className={classes.tableContainer}>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>제품명</TableCell>
+                            <TableCell align="right">판매량</TableCell>
+                            <TableCell align="right">총 매출 (원)</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {tableData.map((product, index) => (
+                            <TableRow key={index}>
+                                <TableCell>{product.name}</TableCell>
+                                <TableCell align="right">{product.totalSales}</TableCell>
+                                <TableCell align="right">{formatRevenue(product.totalRevenue)}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+
+            <Typography variant="h6" align="center" style={{ marginTop: 20 }}>
+                이번 달 총 판매 금액: {formatRevenue(totalRevenue)} 원
+            </Typography>
+
+            <Typography variant="h5" align="center" gutterBottom className={classes.title}>
+                연도별 매출
+            </Typography>
+            <div className={classes.chartContainer}>
+                <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={yearlySalesData}>
+                        <XAxis dataKey="year" />
+                        <YAxis tickFormatter={formatYAxisTicks} />
+                        <Tooltip formatter={(value) => formatRevenue(value)} />
+                        <Bar dataKey="revenue" fill="#82ca9d" />
+                    </BarChart>
+                </ResponsiveContainer>
+            </div>
+
+            <TableContainer component={Paper} className={classes.tableContainer}>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>연도</TableCell>
+                            <TableCell align="right">매출 (원)</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {yearlySalesData.map((data, index) => (
+                            <TableRow key={index}>
+                                <TableCell>{data.year}</TableCell>
+                                <TableCell align="right">{formatRevenue(data.revenue)}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+
+            <Typography variant="h5" align="center" gutterBottom className={classes.title}>
+                월별 매출
+            </Typography>
+            <div className={classes.chartContainer}>
+                <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={monthlySalesData}>
+                        <XAxis dataKey="month" />
+                        <YAxis tickFormatter={formatYAxisTicks} />
+                        <Tooltip formatter={(value) => formatRevenue(value)} />
+                        <Bar dataKey="revenue" fill="#ffc658" />
+                    </BarChart>
+                </ResponsiveContainer>
+            </div>
+
+            <TableContainer component={Paper} className={classes.tableContainer}>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>월</TableCell>
+                            <TableCell align="right">매출 (원)</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {monthlySalesData.map((data, index) => (
+                            <TableRow key={index}>
+                                <TableCell>{data.month}</TableCell>
+                                <TableCell align="right">{formatRevenue(data.revenue)}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        </div>
+    );
+};
+
+export default SellChart;

--- a/AutumnShop/front/Autumnshop/package-lock.json
+++ b/AutumnShop/front/Autumnshop/package-lock.json
@@ -21,7 +21,8 @@
         "react-cookie": "^4.1.1",
         "react-daum-postcode": "^3.2.0",
         "react-dom": "18.2.0",
-        "react-google-recaptcha": "^3.1.0"
+        "react-google-recaptcha": "^3.1.0",
+        "recharts": "^2.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -987,6 +988,60 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -1159,6 +1214,116 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -1174,6 +1339,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1209,6 +1379,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/find-root": {
@@ -1317,6 +1500,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arrayish": {
@@ -1450,6 +1641,11 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1723,9 +1919,23 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
@@ -1740,6 +1950,44 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.1.tgz",
+      "integrity": "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -1836,6 +2084,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -1853,6 +2106,27 @@
       "dependencies": {
         "@types/cookie": "^0.3.3",
         "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/yaml": {

--- a/AutumnShop/front/Autumnshop/package.json
+++ b/AutumnShop/front/Autumnshop/package.json
@@ -22,6 +22,7 @@
     "react-cookie": "^4.1.1",
     "react-daum-postcode": "^3.2.0",
     "react-dom": "18.2.0",
-    "react-google-recaptcha": "^3.1.0"
+    "react-google-recaptcha": "^3.1.0",
+    "recharts": "^2.15.1"
   }
 }

--- a/AutumnShop/front/Autumnshop/pages/mypage/index.js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/index.js
@@ -6,6 +6,7 @@ import PassCheck from "../../components/mypage/passCheck";
 import RecentProducts from "../../components/mypage/recentProducts";
 import GetFavorites from "../../components/mypage/getFavorites";
 import PasswordEdit from "../../components/mypage/passwordEdit";
+import SellChart from "../../components/mypage/sellChart";
 
 const useStyles = makeStyles({
   sidebar: {
@@ -16,7 +17,7 @@ const useStyles = makeStyles({
     flexDirection: "column",
     padding: "16px",
     boxShadow: "2px 0 5px rgba(0, 0, 0, 0.1)",
-    height: "100vh",
+    height: "auto",
   },
   content: {
     marginTop: "30px",
@@ -29,7 +30,7 @@ const useStyles = makeStyles({
     backgroundColor: "#fff",
     borderRadius: "8px",
     boxShadow: "0 0 10px rgba(0, 0, 0, 0.1)",
-    height: "100vh",
+    height: "auto",
   },
   title: {
     marginBottom: "16px",
@@ -94,6 +95,7 @@ const useStyles = makeStyles({
 const MyPage = () => {
   const [userInfo, setUserInfo] = useState(null);
   const [activeSection, setActiveSection] = useState("profile");
+  const [isAdmin, setIsAdmin] = useState(false);
   const classes = useStyles();
 
   useEffect(() => {
@@ -201,6 +203,8 @@ const MyPage = () => {
         return <PassCheck />
       case "edit" :
         return <PasswordEdit />
+      case "sellChart" :
+        return <SellChart />
       default:
         return null;
     }
@@ -259,6 +263,15 @@ const MyPage = () => {
         >
           개인정보 수정
         </Button>
+        {userInfo.roles[0].name === "ROLE_ADMIN" && (
+        <Button
+          variant={activeSection === "sellChart" ? "contained" : "text"}
+          onClick={() => setActiveSection("sellChart")}
+          className={`${classes.button} ${activeSection === "sellChart" ? classes.activeButton : ""}`}
+        >
+          판매 지표 확인
+        </Button>
+        )}
       </Box>
 
       {/* 내용 */}
@@ -270,6 +283,7 @@ const MyPage = () => {
           {activeSection === "recent" && "최근 본 상품"}
           {activeSection === "edit" && "비밀번호 수정"}
           {activeSection === "check" && "개인정보 수정"}
+          {activeSection === "sellChart" && "판매 지표 확인"}
         </Typography>
         <Divider className={classes.divider} />
         {renderSection()}

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/controller/PaymentController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/controller/PaymentController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -59,5 +60,11 @@ public class PaymentController {
     @GetMapping("/get")
     public ResponseEntity<List<Payment>> getPaymentListMember(@IfLogin LoginUserDto loginUserDto){
         return ResponseEntity.ok(paymentService.getPayment(loginUserDto.getMemberId()));
+    }
+
+    @GetMapping("/findAll")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<Payment>> getAllPayment(@IfLogin LoginUserDto loginUserDto){
+        return ResponseEntity.ok(paymentService.getAllPayment());
     }
 }

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Payment/service/PaymentService.java
@@ -320,4 +320,9 @@ public class PaymentService {
             throw new BusinessLogicException(ExceptionCode.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @Transactional
+    public List<Payment> getAllPayment(){
+        return paymentRepository.findAll();
+    }
 }


### PR DESCRIPTION
close #149 

1. 구매 데이터를 가져와 제품별 판매량 및 매출 계산 로직 구현
2. Recharts를 활용해 제품별 판매량을 막대 그래프로 표시
3. MUI Table을 활용해 제품별 판매량과 매출을 데이터 테이블로 구현
4. 이번 년도 매출량, 연도별 매출, 월별 매출을 막대 그래프로 표시한 후, 밑에 데이터 테이블로 구현함
5. 내 정보 페이지에서 관리자 권한 확인 후 '관리자'일 경우에만 해당 컴포넌트를 렌더링할 수 있는 버튼이 표시됨 또한, 판매 지표 확인 컴포넌트에서도 관리자 권한 확인 후 해당되지 않는다면 아무것도 표시하지 않고 /welcome 페이지로 이동하도록 함.