### PR TITLE
판매 지표 스타일 개선 및 기능 추가

### DIFF
--- a/AutumnShop/front/Autumnshop/components/mypage/sellChart.js
+++ b/AutumnShop/front/Autumnshop/components/mypage/sellChart.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { makeStyles } from "@mui/styles";
-import { Typography, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, Paper } from "@mui/material";
+import { Typography, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, Paper, CircularProgress, Select, MenuItem, FormControl, InputLabel, Dialog, DialogActions, DialogContent, DialogTitle, Button } from "@mui/material";
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
 
 const useStyles = makeStyles({
     chartContainer: {
-        height: 300, 
+        height: 300,
         marginBottom: 30,
         width: 700,
     },
@@ -14,10 +14,23 @@ const useStyles = makeStyles({
     },
     title: {
         marginTop: 60,
-    }
+    },
+    loaderContainer: {
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh', // 화면 전체를 채우게 하여 중앙에 표시
+    },
+    filterContainer: {
+        display: 'flex',
+        justifyContent: 'center',
+        marginTop: 20,
+    },
 });
 
-async function getPaymentList(loginInfo, setPaymentList) {
+// 결제 정보 조회
+async function getPaymentList(loginInfo, setPaymentList, setLoading) {
+    setLoading(true);
     try {
         const paymentResponse = await fetch("http://localhost:8080/payment/findAll", {
             method: "GET",
@@ -27,6 +40,8 @@ async function getPaymentList(loginInfo, setPaymentList) {
         setPaymentList(paymentData);
     } catch (error) {
         console.log(error);
+    } finally {
+        setLoading(false); // 데이터 로딩 후 로딩 상태 false
     }
 }
 
@@ -34,52 +49,56 @@ const SellChart = () => {
     const classes = useStyles();
     const [paymentList, setPaymentList] = useState([]);
     const [isAdmin, setIsAdmin] = useState(false);
-    const currentYear = new Date().getFullYear();  // 현재 년도
+    const [loading, setLoading] = useState(false); // 로딩 상태 관리
+    const [filter, setFilter] = useState("yearly"); // 필터 상태 관리 (월별, 연도별)
+    const [openModal, setOpenModal] = useState(false);  // 모달 열림 여부
+    const [selectedProduct, setSelectedProduct] = useState(null);  // 선택된 제품 정보
+    const currentYear = new Date().getFullYear(); // 현재 년도
 
     useEffect(() => {
         const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
         const getUserInfo = async () => {
-      
             if (!loginInfo || !loginInfo.accessToken) {
-              window.location.href = "/login";
-              return;
+                window.location.href = "/login";
+                return;
             }
-      
+
+            // 로그인 한 사용자의 권한이 관리자(ADMIN)인지 확인
             try {
-              const response = await fetch("http://localhost:8080/members/info", {
-                method: "GET",
-                headers: {
-                  Authorization: `Bearer ${loginInfo.accessToken}`,
-                },
-              });
-      
-              if(!response.ok){
-                throw new error;
-              }
-      
-              const data = await response.json();
-      
-              if (data.roles.some(role => role.name === "ROLE_ADMIN")) {
-                setIsAdmin(true);
-              } else {
-                setIsAdmin(false);
-              }
-      
-              if(data.roles[0].name != "ROLE_ADMIN"){
-                throw error;
-              }
+                const response = await fetch("http://localhost:8080/members/info", {
+                    method: "GET",
+                    headers: {
+                        Authorization: `Bearer ${loginInfo.accessToken}`,
+                    },
+                });
+
+                if (!response.ok) {
+                    throw new error;
+                }
+
+                const data = await response.json();
+
+                if (data.roles.some(role => role.name === "ROLE_ADMIN")) {
+                    setIsAdmin(true);
+                } else {
+                    setIsAdmin(false);
+                }
+
+                if (data.roles[0].name !== "ROLE_ADMIN") {
+                    throw error;
+                }
             } catch (error) {
-              window.location.href = "/welcome";
+                window.location.href = "/welcome";
             }
-          };
-      
-          getUserInfo();
-        getPaymentList(loginInfo, setPaymentList);
+        };
+
+        getUserInfo();
+        getPaymentList(loginInfo, setPaymentList, setLoading);
     }, []);
 
-    const productSales = {};
-    const yearlySales = {};
-    const monthlySales = {};
+    const productSales = {}; // 각 차트의 물건 판매량
+    const yearlySales = {}; // 연도 판매량
+    const monthlySales = {}; // 월간 판매량
     const currentYearSales = {}; // 이번 년도 판매량
 
     paymentList.forEach((payment) => {
@@ -110,19 +129,25 @@ const SellChart = () => {
         monthlySales[monthKey] += quantity * price;
     });
 
+    // Y축 값에 대해 "억" 또는 "만" 단위로 변환하는 함수
     const formatYAxisTicks = (value) => {
+        // 1억 이상일 경우 "억" 단위로 변환
         if (value >= 100000000) {
             return `${(value / 100000000).toFixed(1)}억`;
-        } else if (value >= 10000) {
+        } // 1만 이상일 경우 "만" 단위로 변환
+        else if (value >= 10000) {
             return `${(value / 10000).toFixed(1)}만`;
         }
         return value;
     };
 
+    // 숫자 값을 천 단위로 구분하여 형식화
     const formatRevenue = (value) => {
         return value.toLocaleString();
     };
+    
 
+    // 이번 년도 판매량의 각 차트 데이터
     const chartData = Object.values(productSales).map((product) => ({
         name: product.name,
         sales: product.totalSales,
@@ -131,23 +156,77 @@ const SellChart = () => {
     const tableData = Object.values(productSales);
     const totalRevenue = tableData.reduce((sum, product) => sum + product.totalRevenue, 0);
 
+    // 연간 판매량의 차트 데이터
     const yearlySalesData = Object.keys(yearlySales).map((year) => ({
         year,
         revenue: yearlySales[year],
     }));
 
-    const monthlySalesData = Object.keys(monthlySales)
-    .map((month) => ({
-        month,
-        revenue: monthlySales[month],
-    }))
-    .sort((a, b) => {
-        const [yearA, monthA] = a.month.split("-");
-        const [yearB, monthB] = b.month.split("-");
-        return new Date(yearA, monthA - 1) - new Date(yearB, monthB - 1);  // 날짜를 비교하여 정렬
-    });
 
-    if(!isAdmin){
+    // 매출 목표 설정
+    const targetRevenue = 14260000; // 목표 매출 : 7백만
+
+    // 목표 달성 여부 체크
+    const isTargetAchieved = totalRevenue >= targetRevenue;
+
+    // 목표 달성 시 파란색, 미달성 시 빨간색
+    const chartBarColor = isTargetAchieved ? "#82ca9d" : "#ff6666";
+
+
+    // 날짜 형식 MMMM - DD -> 월간 포맷팅
+    const formatMonth = (month) => {
+        const [year, monthNum] = month.split("-");
+        const monthNames = [
+            "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
+        ];
+        return `${year}년 ${monthNames[parseInt(monthNum, 10) - 1]}`;
+    };
+
+    // 월간 판매량의 차트 데이터
+    const monthlySalesData = Object.keys(monthlySales)
+        .map((month) => ({
+            month: formatMonth(month),  // 포맷팅된 월을 사용
+            revenue: monthlySales[month],
+        }))
+        .sort((a, b) => {
+            const [yearA, monthA] = a.month.split("년 ");
+            const [yearB, monthB] = b.month.split("년 ");
+            return new Date(yearA, monthA.replace('월', '') - 1) - new Date(yearB, monthB.replace('월', '') - 1);  // 날짜를 비교하여 정렬
+        });
+
+    // 월간, 연도별로 필터링
+    const handleFilterChange = (event) => {
+        setFilter(event.target.value);
+    };
+
+
+    // 이번 년도 판매량 차트의 그래프 클릭 시 모달 창에 보여주기 위함
+    const handleItemClick = (name) => {
+        const productData = chartData.find(item => item.name === name);
+        const paymentData = paymentList.find(payment => payment.product.title === name);
+        if (productData) {
+            setSelectedProduct({
+                name: productData.name,
+                sales: productData.sales,
+                price: paymentData.product.price,
+            });
+            setOpenModal(true);
+        }
+    };
+    // 모달 닫기
+    const handleCloseModal = () => {
+        setOpenModal(false);
+    };
+
+    if (loading) {
+        return (
+            <div className={classes.loaderContainer}>
+                <CircularProgress />
+            </div>
+        );
+    }
+
+    if (!isAdmin) {
         return null;
     }
 
@@ -156,16 +235,45 @@ const SellChart = () => {
             <Typography variant="h5" align="center" gutterBottom>
                 이번 년도 판매량
             </Typography>
+            <Typography 
+                variant="h6" 
+                align="center" 
+                gutterBottom
+                style={{ color: isTargetAchieved ? 'blue' : 'red' }} // 목표 달성 여부에 따라 색상 변경
+            >
+                매출 목표: {formatRevenue(targetRevenue)}원 | 현재 매출 : {formatRevenue(totalRevenue)}원 | {isTargetAchieved ? '목표 달성' : '목표 미달성'}
+            </Typography>
             <div className={classes.chartContainer}>
                 <ResponsiveContainer width="100%" height="100%">
-                    <BarChart data={chartData}>
+                    <BarChart data={chartData} margin={{ left: 60, right: 20, top: 20, bottom: 20 }}>
                         <XAxis dataKey="name" />
                         <YAxis tickFormatter={formatYAxisTicks} />
                         <Tooltip formatter={(value) => formatRevenue(value)} />
-                        <Bar dataKey="sales" fill="#8884d8" />
+                        <Bar dataKey="sales" fill={chartBarColor}
+                        onClick={(data) => handleItemClick(data.name)}/>
                     </BarChart>
                 </ResponsiveContainer>
             </div>
+
+            {/* 모달 창 */}
+            <Dialog open={openModal} onClose={handleCloseModal}>
+                <DialogTitle>제품 상세 정보</DialogTitle>
+                <DialogContent>
+                    {selectedProduct && (
+                        <>
+                            <Typography variant="h5">{selectedProduct.name}</Typography> {/* 제품 이름 */}
+                            <Typography>판매량: {selectedProduct.sales}</Typography> {/* 판매량 */}
+                            <Typography>가격: {formatRevenue(selectedProduct.price)}원</Typography> {/* 가격 */}
+                            <Typography>
+                                총 매출: {formatRevenue(selectedProduct.sales * selectedProduct.price)}원
+                            </Typography> {/* 판매량 * 가격으로 총 매출 계산 */}
+                        </>
+                    )}
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleCloseModal} color="primary">닫기</Button>
+                </DialogActions>
+            </Dialog>
 
             <TableContainer component={Paper} className={classes.tableContainer}>
                 <Table>
@@ -188,75 +296,87 @@ const SellChart = () => {
                 </Table>
             </TableContainer>
 
-            <Typography variant="h6" align="center" style={{ marginTop: 20 }}>
-                이번 달 총 판매 금액: {formatRevenue(totalRevenue)} 원
-            </Typography>
-
-            <Typography variant="h5" align="center" gutterBottom className={classes.title}>
-                연도별 매출
-            </Typography>
-            <div className={classes.chartContainer}>
-                <ResponsiveContainer width="100%" height="100%">
-                    <BarChart data={yearlySalesData}>
-                        <XAxis dataKey="year" />
-                        <YAxis tickFormatter={formatYAxisTicks} />
-                        <Tooltip formatter={(value) => formatRevenue(value)} />
-                        <Bar dataKey="revenue" fill="#82ca9d" />
-                    </BarChart>
-                </ResponsiveContainer>
+            <div className={classes.filterContainer}>
+                <FormControl variant="outlined">
+                    <InputLabel>필터</InputLabel>
+                    <Select
+                        value={filter}
+                        onChange={handleFilterChange}
+                        label="필터"
+                    >
+                        <MenuItem value="monthly">월별</MenuItem>
+                        <MenuItem value="yearly">연도별</MenuItem>
+                    </Select>
+                </FormControl>
             </div>
 
-            <TableContainer component={Paper} className={classes.tableContainer}>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>연도</TableCell>
-                            <TableCell align="right">매출 (원)</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {yearlySalesData.map((data, index) => (
-                            <TableRow key={index}>
-                                <TableCell>{data.year}</TableCell>
-                                <TableCell align="right">{formatRevenue(data.revenue)}</TableCell>
-                            </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </TableContainer>
+            {filter === "yearly" && (
+                <>
+                    <div className={classes.chartContainer}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <BarChart data={yearlySalesData} margin={{ left: 60, right: 20, top: 20, bottom: 20 }}>
+                                <XAxis dataKey="year" />
+                                <YAxis tickFormatter={formatYAxisTicks} />
+                                <Tooltip formatter={(value) => formatRevenue(value)} />
+                                <Bar dataKey="revenue" fill="#82ca9d" />
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
 
-            <Typography variant="h5" align="center" gutterBottom className={classes.title}>
-                월별 매출
-            </Typography>
-            <div className={classes.chartContainer}>
-                <ResponsiveContainer width="100%" height="100%">
-                    <BarChart data={monthlySalesData}>
-                        <XAxis dataKey="month" />
-                        <YAxis tickFormatter={formatYAxisTicks} />
-                        <Tooltip formatter={(value) => formatRevenue(value)} />
-                        <Bar dataKey="revenue" fill="#ffc658" />
-                    </BarChart>
-                </ResponsiveContainer>
-            </div>
+                    <TableContainer component={Paper} className={classes.tableContainer}>
+                        <Table>
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>연도</TableCell>
+                                    <TableCell align="right">매출 (원)</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {yearlySalesData.map((data, index) => (
+                                    <TableRow key={index}>
+                                        <TableCell>{data.year}</TableCell>
+                                        <TableCell align="right">{formatRevenue(data.revenue)}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                </>
+            )}
 
-            <TableContainer component={Paper} className={classes.tableContainer}>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>월</TableCell>
-                            <TableCell align="right">매출 (원)</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {monthlySalesData.map((data, index) => (
-                            <TableRow key={index}>
-                                <TableCell>{data.month}</TableCell>
-                                <TableCell align="right">{formatRevenue(data.revenue)}</TableCell>
-                            </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </TableContainer>
+            {filter === "monthly" && (
+                <>
+                    <div className={classes.chartContainer}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <BarChart data={monthlySalesData} margin={{ left: 60, right: 20, top: 20, bottom: 20 }}>
+                                <XAxis dataKey="month" />
+                                <YAxis tickFormatter={formatYAxisTicks} />
+                                <Tooltip formatter={(value) => formatRevenue(value)} />
+                                <Bar dataKey="revenue" fill="#ffc658" />
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+
+                    <TableContainer component={Paper} className={classes.tableContainer}>
+                        <Table>
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>월</TableCell>
+                                    <TableCell align="right">매출 (원)</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {monthlySalesData.map((data, index) => (
+                                    <TableRow key={index}>
+                                        <TableCell>{data.month}</TableCell>
+                                        <TableCell align="right">{formatRevenue(data.revenue)}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                </>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
close #151 

1. 판매 날짜를 YYYY-MM-DD 형식에서 YYYY년 MM월로 변경함. (ex : 2025년 3월)

2. 데이터 로딩 중 로딩 스피너 or 로딩 메시지를 표시해 로딩 상태를 알리게 함.

3. 사용자의 선택에 따라 차트 데이터(ex: 연도별, 월별, ...)를 필터링할 수 있도록 함. select를 이용하여 각 선택에 따라 다른 차트 데이터를 렌더링되게 함.

4. 이번 년도 판매량 밑에 이번 달 매출 목표를 맨 위에 표시하고  총 매출, 현재 매출액을 표시한 후 밑에 차트를 표시했음., 설정된 매출 목표를 달성했을 때 차트 색상 및 위의 매출액 글자 색상을 변경하게 하였음. ( 미달성 : 빨간색, 달성 : 파란색)

5. 차트에서 아이템을 클릭 시, 해당 아이템의 상세 정보를 모달 창으로 보여줌. 판매량, 가격, 그 물건의 총 매출을 보여주도록 함.