### PR TITLE
신고 내용 페이지 기능 완료

### DIFF
--- a/AutumnShop/front/Autumnshop/components/mypage/getReport.js
+++ b/AutumnShop/front/Autumnshop/components/mypage/getReport.js
@@ -71,12 +71,42 @@ const useStyles = makeStyles({
         },
         alignSelf: "flex-start",  // 버튼을 왼쪽에 정렬
         marginTop: "auto",  // 맨 아래로 배치
-    }
+    },
+    paginationContainer: {
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        marginTop: "20px",
+    },
+    paginationButton: {
+        padding: "8px 15px",
+        border: "2px solid #000",
+        borderRadius: "4px",
+        backgroundColor: "#fff",
+        cursor: "pointer",
+        color: "#000",
+        fontWeight: "bold",
+        fontSize: "14px",
+        "&:disabled": {
+            backgroundColor: "#e0e0e0",
+            cursor: "not-allowed",
+        },
+        "&:hover:not(:disabled)": {
+            backgroundColor: "#f1f1f1",
+        },
+    },
+    currentPage: {
+        fontWeight: "bold",
+        fontSize: "16px",
+        margin: "0 10px",
+    },
 });
 
 const ReportPage = () => {
     const [reports, setReports] = useState([]);
     const [isAdmin, setIsAdmin] = useState(false);
+    const [page, setPage] = useState(0);
+    const [totalPages, setTotalPages] = useState(1);
     const classes = useStyles();
 
     useEffect(() => {
@@ -100,23 +130,26 @@ const ReportPage = () => {
             }
         };
 
+
         const fetchReports = async () => {
             try {
-                const response = await fetch("http://localhost:8080/report", {
+                const response = await fetch(`http://localhost:8080/report?page=${page}`, {
                     method: "GET",
                     headers: { Authorization: `Bearer ${loginInfo.accessToken}` },
                 });
                 if (!response.ok) throw new Error();
                 const data = await response.json();
-                setReports(data);
+                setReports(data.content);
+                setTotalPages(data.totalPages);
             } catch (error) {
                 console.error("Error fetching reports", error);
             }
         };
 
+
         getUserInfo();
         fetchReports();
-    }, []);
+    }, [page]);
 
     if (!isAdmin) return null;
 
@@ -144,6 +177,41 @@ const ReportPage = () => {
                     </div>
                 </div>
             ))}
+
+            {/* 페이지네이션 UI */}
+            <div className={classes.paginationContainer}>
+                <button
+                    className={classes.paginationButton}
+                    onClick={() => setPage(0)}
+                    disabled={page === 0}
+                >
+                    첫페이지
+                </button>
+                <button
+                    className={classes.paginationButton}
+                    onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+                    disabled={page === 0}
+                >
+                    이전
+                </button>
+                <span className={classes.currentPage}>
+                    {page + 1} / {totalPages}
+                </span>
+                <button
+                    className={classes.paginationButton}
+                    onClick={() => setPage((prev) => Math.min(prev + 1, totalPages - 1))}
+                    disabled={page === totalPages - 1}
+                >
+                    다음
+                </button>
+                <button
+                    className={classes.paginationButton}
+                    onClick={() => setPage(totalPages - 1)}
+                    disabled={page === totalPages - 1}
+                >
+                    마지막페이지
+                </button>
+            </div>
         </div>
     );
 };

--- a/AutumnShop/front/Autumnshop/pages/mypage/report/[id].js
+++ b/AutumnShop/front/Autumnshop/pages/mypage/report/[id].js
@@ -131,10 +131,10 @@ const ReportDetailPage = () => {
                 신고 내용
             </Typography>
             <div className={classes.text}>
-                <strong>상품 ID:</strong> {report.product.id}
+                <strong>물품 ID:</strong> {report.product.id}
             </div>
             <div className={classes.text}>
-                <strong>상품 이름: </strong> {report.product.title}
+                <strong>물품 이름: </strong> {report.product.title}
             </div>
             <div className={classes.text}>
                 <img

--- a/AutumnShop/front/Autumnshop/pages/product/reportPage.js
+++ b/AutumnShop/front/Autumnshop/pages/product/reportPage.js
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) => ({
     margin: '0 auto',
   },
   formBox: {
-    width: 400,
+    width: 600,
     textAlign: "center",
   },
   button: {
@@ -75,7 +75,7 @@ const ReportPage = () => {
     <Box className={classes.container}>
       <Box className={classes.formBox}>
         <Typography variant="h4" gutterBottom>
-          상품평 신고
+          물품 신고
         </Typography>
         <TextField
           label="신고 사유"

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/controller/ProductController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/controller/ProductController.java
@@ -46,7 +46,8 @@ public class ProductController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<Product>> getProducts(@RequestParam(required = false, defaultValue = "0") Long categoryId, @RequestParam(required = false, defaultValue = "0") int page) {
+    public ResponseEntity<Page<Product>> getProducts(@RequestParam(required = false, defaultValue = "0") Long categoryId,
+                                                     @RequestParam(required = false, defaultValue = "0") int page) {
         int size = 10;
         if(categoryId == 0)
             return ResponseEntity.ok(productService.getProducts(page, size));

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/controller/ReportController.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/controller/ReportController.java
@@ -9,6 +9,7 @@ import com.example.AutumnMall.exception.ExceptionCode;
 import com.example.AutumnMall.security.jwt.util.IfLogin;
 import com.example.AutumnMall.security.jwt.util.LoginUserDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,8 +35,10 @@ public class ReportController {
 
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
-    public List<Report> findReportAll(){
-        return reportService.findReportAll();
+    public Page<Report> findReport(@RequestParam (required = false, defaultValue = "0") int page){
+        int size = 10;
+
+        return reportService.findReport(page, size);
     }
 
     @GetMapping("/{id}")

--- a/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ReportService.java
+++ b/AutumnShop/src/main/java/com/example/AutumnMall/Product/service/ReportService.java
@@ -11,6 +11,8 @@ import com.example.AutumnMall.exception.BusinessLogicException;
 import com.example.AutumnMall.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,8 +52,8 @@ public class ReportService {
         return reportRepository.save(report);
     }
 
-    public List<Report> findReportAll(){
-        return reportRepository.findAll();
+    public Page<Report> findReport(int page, int size){
+        return reportRepository.findAll(PageRequest.of(page, size));
     }
 
     public Optional<Report> findReport(Long reportId){


### PR DESCRIPTION
close #156 

1. '내 정보' 페이지의 '신고 목록' 페이지를 모두 조회하던 형식에서 '물품 목록', '주문 목록' 페이지와 같이 10개의 사이즈로 페이지 형식으로 조회함.
2. productController에서 매개 변수 가독성을 위한 줄바꿈 및 신고 추가 페이지 css 조정