### PR TITLE
물품이 아예 없을 때 페이지 내에서 섹션 이동이 적거나 이동할 좌표가 동일해 오류가 생기던 점 수정

### DIFF
--- a/AutumnShop/front/Autumnshop/pages/welcome.js
+++ b/AutumnShop/front/Autumnshop/pages/welcome.js
@@ -187,15 +187,20 @@ const MainPage = () => {
     setValue(newValue);
   
     const targetElement = sectionRefs[newValue].current;
-  
+    
     if (targetElement) {
       const elementPosition = targetElement.getBoundingClientRect().top;
       const offsetPosition = elementPosition + window.pageYOffset - 130; // 앱바 고려하여 좌표 조정
   
-      window.scrollTo({
-        top: offsetPosition,
-        behavior: "smooth",
-      });
+      // 현재 스크롤 위치와 비교 후 이동
+      if (Math.abs(window.pageYOffset - offsetPosition) > 1) {
+        window.scrollTo({
+          top: offsetPosition,
+          behavior: "smooth",
+        });
+      }
+    } else {
+      console.warn("선택한 섹션이 존재하지 않습니다.");
     }
   };
 


### PR DESCRIPTION
close #168 

해당 섹션의 ref가 존재하지 않거나 스크롤 위치가 동일할 경우 이동하지 않도록 함